### PR TITLE
Add modern shell tools to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
     "ghcr.io/nils-geistmann/devcontainers-features/zsh:0": {
       "plugins": "git colored-man-pages colorize history zsh-autosuggestions fast-syntax-highlighting zsh-autocomplete"
     },
+    "ghcr.io/meaningfy-ws/devcontainer-features/modern-shell-tools:1": {},
     "ghcr.io/guiyomh/features/just:0.1.0": { "version": "1.42.4" },
     "ghcr.io/devcontainers/features/python:1": {
       "version": "os-provided",
@@ -42,7 +43,7 @@
   "remoteEnv": {
     "AWS_REGION": "us-west-2"
   },
-  "postCreateCommand": "bash ./.devcontainer/postCreateCommand.sh && bash ./.devcontainer/installOhmyzshPlugins.sh",
+  "postCreateCommand": "bash ./.devcontainer/installOhmyzshPlugins.sh && bash ./.devcontainer/setupShellAliases.sh && bash ./.devcontainer/postCreateCommand.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/setupShellAliases.sh
+++ b/.devcontainer/setupShellAliases.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Set up shell aliases for modern tools
+# These tools are installed via the modern-shell-tools devcontainer feature
+
+# Create or append to .zshrc
+ZSHRC="$HOME/.zshrc"
+
+# Check if aliases already exist to avoid duplicates
+if ! grep -q "# Modern shell tool aliases" "$ZSHRC" 2>/dev/null; then
+    cat >> "$ZSHRC" << 'EOF'
+
+# Modern shell tool aliases
+alias ls='eza'
+alias cat='bat --paging=never'
+alias grep='ag'
+EOF
+    echo "Shell aliases configured successfully"
+else
+    echo "Shell aliases already configured"
+fi


### PR DESCRIPTION
## Summary

This PR adds modern shell tools (eza, bat, ag, fd) to the devcontainer configuration with convenient aliases.

## Changes

### 1. Updated 
- Added `modern-shell-tools` feature to install eza, bat, ag, and fd
- Updated `postCreateCommand` to call `setupShellAliases.sh` in the correct order (after zsh plugins but before postCreateCommand)

### 2. Created Shell aliases configured successfully
- New script that configures shell aliases in `.zshrc`
- Aliases configured:
  - `ls` → `eza` (modern ls with colors and icons)
  - `cat` → `bat --paging=never` (syntax highlighting without paging)
  - `grep` → `ag` (silver searcher, much faster)
- `fd` is intentionally NOT aliased (use explicitly when needed)
- Script checks for existing aliases to avoid duplicates

## Benefits

- **eza**: Better file listing with colors, git integration, and icons
- **bat**: Syntax-highlighted file viewing with line numbers
- **ag**: Blazing-fast code searching (significantly faster than grep)
- **fd**: Modern file finder (available explicitly via `fd` command)

## Testing

After rebuilding the devcontainer:
- `ls` should show eza's colorful output
- `cat README.md` should show bat's syntax-highlighted output (no paging)
- `grep "pattern" file` should use ag
- `fd filename` should work explicitly