### PR TITLE
Add residential delivery revenue requirements

### DIFF
--- a/reports/ny_hp_rates/index.qmd
+++ b/reports/ny_hp_rates/index.qmd
@@ -424,14 +424,14 @@ Residential delivery revenue requirements were found from the most recent rate c
 
 Table: Residential delivery revenue requirements ($000s)
 
-| Utility | Year | Revenue requirement ($000s) | Source |
-| --- | ---: | ---: | --- |
-| Central Hudson | 2025 | $394,388 | [Docket 24-E-01580](https://www.documentcloud.org/documents/27354700-joint-proposals-and-stipulations-05-13-2025-joint-proposal-and-appendices-45770242/#document/p213/a2804860) |
-| Niagara Mohawk | 2025 | $1,314,441 | [Docket 24-E-0322](https://www.documentcloud.org/documents/27422700-joint-proposals-and-stipulations-04-25-2025-appendix-2-schedule-5-appendix-2-schedule-16-nmpc-joint-proposal-61180221/#document/p187/a2804589) |
-| Orange & Rockland | 2025 | $248,359 | [Docket 24-E-0060](https://www.documentcloud.org/documents/27422823-joint-proposals-and-stipulations-11-08-2024-joint-proposal-and-appendices-45147253/#document/p314/a2804590) |
-| Rochester Gas & Electric | 2025 | $325,583 | [Docket 25-E-01376](https://www.documentcloud.org/documents/27422850-exhibits-09-26-2025-revenue-allocation-and-rate-design-panel-supplemental-candu-exhibits-61117988/#document/p2/a2804672) |
-| New York State Electric & Gas | 2025 | $834,674 | [Docket 25-E-01376](https://www.documentcloud.org/documents/27422850-exhibits-09-26-2025-revenue-allocation-and-rate-design-panel-supplemental-candu-exhibits-61117988/#document/p1/a2804616) |
-| Con Edison | 2025 | $3,116,197 | [Docket 25-E-00241](https://www.documentcloud.org/documents/27687458-correspondence-01-31-2025-2025-filing-letter-and-attachments-11531948/#document/p104/a2804859) |
+| Utility | Effective start | Effective end | Revenue requirement ($000s) | Source |
+| --- | --- | --- | ---: | --- |
+| Central Hudson | July 1, 2025 | June 30, 2026 | $394,388 | [Docket 24-E-01580](https://www.documentcloud.org/documents/27354700-joint-proposals-and-stipulations-05-13-2025-joint-proposal-and-appendices-45770242/#document/p213/a2804860) @cenhud_Docket24E01580Joint_2025 |
+| Niagara Mohawk | April 1, 2025 | March 31, 2026 | $1,314,441 | [Docket 24-E-0322](https://www.documentcloud.org/documents/27422700-joint-proposals-and-stipulations-04-25-2025-appendix-2-schedule-5-appendix-2-schedule-16-nmpc-joint-proposal-61180221/#document/p187/a2804589) @nimo_Docket24E0322Joint_2025|
+| Orange & Rockland | January 1, 2025 | December 31, 2025 | $248,359 | [Docket 24-E-0060](https://www.documentcloud.org/documents/27422823-joint-proposals-and-stipulations-11-08-2024-joint-proposal-and-appendices-45147253/#document/p314/a2804590) @o&r_Docket24E0060Joint_2024|
+| Rochester Gas & Electric | May 1, 2025 | April 30, 2026 | $325,583 | [Docket 25-E-01376](https://www.documentcloud.org/documents/27422850-exhibits-09-26-2025-revenue-allocation-and-rate-design-panel-supplemental-candu-exhibits-61117988/#document/p2/a2804672) @nysegrg&e_Docket25E01376Exhibits_2025|
+| New York State Electric & Gas | May 1, 2025 | April 30, 2026 | $834,674 | [Docket 25-E-01376](https://www.documentcloud.org/documents/27422850-exhibits-09-26-2025-revenue-allocation-and-rate-design-panel-supplemental-candu-exhibits-61117988/#document/p1/a2804616) @nysegrg&e_Docket25E01376Exhibits_2025|
+| Con Edison | January 1, 2025 | December 31, 2026 | $3,116,197 | [Docket 25-E-00241](https://www.documentcloud.org/documents/27687458-correspondence-01-31-2025-2025-filing-letter-and-attachments-11531948/#document/p104/a2804859) @coned_Docket25E00241Correspondence_2025|
 
 
 ## Assumptions


### PR DESCRIPTION
## Summary
- add residential delivery revenue requirement section and table to ny_hp_rates report
- cite docket sources and document scaling to $000s

## Test plan
- [ ] Preview `reports/ny_hp_rates/index.qmd`

Made with [Cursor](https://cursor.com)