### PR TITLE
[ny_hp_rates] Add load-year BAT & cross-subsidy comparison notebook

### DIFF
--- a/rate-utils/plotting_utils.py
+++ b/rate-utils/plotting_utils.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
 def _parse_s3_uri(uri: str) -> tuple[str, str]:
     """Split an ``s3://bucket/key`` URI into ``(bucket, key)``."""
-    without_prefix = uri[len("s3://"):]
+    without_prefix = uri[len("s3://") :]
     bucket, _, key = without_prefix.partition("/")
     return bucket, key
 
@@ -59,14 +59,13 @@ def find_latest_run_dir(run_base: str, run_name: str) -> str:
 
     bucket, prefix = _parse_s3_uri(run_base)
     prefix = prefix.rstrip("/") + "/"
-    suffix = f"_{run_name}/"
 
     paginator = boto3.client("s3").get_paginator("list_objects_v2")
     matching: list[str] = []
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/"):
         for entry in page.get("CommonPrefixes", []):
             dir_prefix = entry["Prefix"]
-            dir_name = dir_prefix[len(prefix):].rstrip("/")
+            dir_name = dir_prefix[len(prefix) :].rstrip("/")
             if dir_name.endswith(f"_{run_name}"):
                 matching.append(dir_name)
 
@@ -231,6 +230,8 @@ def summarize_cross_subsidy(cross: pd.DataFrame, metadata: pd.DataFrame) -> pd.D
         how="left",
     )
 
+    available = {src: dst for src, dst in _CROSS_SUBSIDY_WEIGHTED_COLS.items() if src in cross.columns}
+
     rows = []
     for has_hp, group in merged.groupby("postprocess_group.has_hp"):
         weight_sum = group["weight"].sum()
@@ -239,16 +240,14 @@ def summarize_cross_subsidy(cross: pd.DataFrame, metadata: pd.DataFrame) -> pd.D
             "customers_weighted": weight_sum,
             "group": "HP" if has_hp else "Non-HP",
         }
-        for source_col, output_col in _CROSS_SUBSIDY_WEIGHTED_COLS.items():
+        for source_col, output_col in available.items():
             row[output_col] = (group[source_col] * group["weight"]).sum() / weight_sum
         rows.append(row)
 
     return pd.DataFrame(rows)
 
 
-def summarize_cross_subsidy_by_heating_type(
-    cross: pd.DataFrame, metadata: pd.DataFrame
-) -> pd.DataFrame:
+def summarize_cross_subsidy_by_heating_type(cross: pd.DataFrame, metadata: pd.DataFrame) -> pd.DataFrame:
     """Compute weighted cross-subsidy metrics grouped by ``postprocess_group.heating_type``.
 
     Returns one row per heating type with the same weighted-average columns as
@@ -260,6 +259,8 @@ def summarize_cross_subsidy_by_heating_type(
         how="left",
     )
 
+    available = {src: dst for src, dst in _CROSS_SUBSIDY_WEIGHTED_COLS.items() if src in cross.columns}
+
     rows = []
     for heating_type, group in merged.groupby("postprocess_group.heating_type"):
         weight_sum = group["weight"].sum()
@@ -268,7 +269,7 @@ def summarize_cross_subsidy_by_heating_type(
             "customers_weighted": weight_sum,
             "group": str(heating_type),
         }
-        for source_col, output_col in _CROSS_SUBSIDY_WEIGHTED_COLS.items():
+        for source_col, output_col in available.items():
             row[output_col] = (group[source_col] * group["weight"]).sum() / weight_sum
         rows.append(row)
 
@@ -309,9 +310,16 @@ def build_cost_mix(cross_summary: pd.DataFrame) -> pd.DataFrame:
             benchmark=lambda d: d["benchmark_key"].map(residual_labels),
             marginal_usd_per_customer_year=lambda d: d["Economic_burden_weighted_avg"],
             weighted_customers=lambda d: d["customers_weighted"],
-        )
-        [[*extra_ids, "group", "benchmark", "weighted_customers",
-          "marginal_usd_per_customer_year", "residual_usd_per_customer_year"]]
+        )[
+            [
+                *extra_ids,
+                "group",
+                "benchmark",
+                "weighted_customers",
+                "marginal_usd_per_customer_year",
+                "residual_usd_per_customer_year",
+            ]
+        ]
     )
 
     totals = cost_mix.assign(
@@ -319,32 +327,32 @@ def build_cost_mix(cross_summary: pd.DataFrame) -> pd.DataFrame:
         residual_total_usd_per_year=lambda d: d["residual_usd_per_customer_year"] * d["weighted_customers"],
     )
 
-    return (
-        totals.melt(
-            id_vars=[*extra_ids, "group", "benchmark"],
-            value_vars=["marginal_total_usd_per_year", "residual_total_usd_per_year"],
-            var_name="cost_source_key",
-            value_name="usd_total_per_year",
-        )
-        .assign(
-            cost_source=lambda d: d["cost_source_key"].map(
-                {
-                    "marginal_total_usd_per_year": "Marginal (economic burden)",
-                    "residual_total_usd_per_year": "Residual allocation",
-                }
-            ),
-            musd_total_per_year=lambda d: d["usd_total_per_year"] / 1e6,
-        )
-        [[*extra_ids, "group", "benchmark", "cost_source", "musd_total_per_year"]]
-    )
+    return totals.melt(
+        id_vars=[*extra_ids, "group", "benchmark"],
+        value_vars=["marginal_total_usd_per_year", "residual_total_usd_per_year"],
+        var_name="cost_source_key",
+        value_name="usd_total_per_year",
+    ).assign(
+        cost_source=lambda d: d["cost_source_key"].map(
+            {
+                "marginal_total_usd_per_year": "Marginal (economic burden)",
+                "residual_total_usd_per_year": "Residual allocation",
+            }
+        ),
+        musd_total_per_year=lambda d: d["usd_total_per_year"] / 1e6,
+    )[[*extra_ids, "group", "benchmark", "cost_source", "musd_total_per_year"]]
 
 
 def build_hourly_group_loads(raw_load_elec: pd.DataFrame, metadata: pd.DataFrame) -> pd.DataFrame:
     """Aggregate weighted hourly electricity load by HP flag and total."""
-    weighted = raw_load_elec[["electricity_net"]].reset_index().merge(
-        metadata[["bldg_id", "postprocess_group.has_hp", "weight"]],
-        on="bldg_id",
-        how="left",
+    weighted = (
+        raw_load_elec[["electricity_net"]]
+        .reset_index()
+        .merge(
+            metadata[["bldg_id", "postprocess_group.has_hp", "weight"]],
+            on="bldg_id",
+            how="left",
+        )
     )
     weighted["weighted_load_kwh"] = weighted["electricity_net"] * weighted["weight"]
 
@@ -366,10 +374,14 @@ def build_hourly_heating_type_loads(raw_load_elec: pd.DataFrame, metadata: pd.Da
     Returns a long-form DataFrame with columns ``time``, ``heating_type``, and
     ``load_kwh`` — one row per (hour, heating type) combination.
     """
-    weighted = raw_load_elec[["electricity_net"]].reset_index().merge(
-        metadata[["bldg_id", "postprocess_group.heating_type", "weight"]],
-        on="bldg_id",
-        how="left",
+    weighted = (
+        raw_load_elec[["electricity_net"]]
+        .reset_index()
+        .merge(
+            metadata[["bldg_id", "postprocess_group.heating_type", "weight"]],
+            on="bldg_id",
+            how="left",
+        )
     )
     weighted["weighted_load_kwh"] = weighted["electricity_net"] * weighted["weight"]
 
@@ -384,24 +396,22 @@ def build_hourly_heating_type_loads(raw_load_elec: pd.DataFrame, metadata: pd.Da
 
 def build_cross_components(cross_summary: pd.DataFrame) -> pd.DataFrame:
     """Build benchmark component contributions for charting cross-subsidy impacts."""
-    component_labels = {
+    _all_component_labels = {
         "BAT_vol_weighted_avg": "Volumetric benchmark",
         "BAT_peak_weighted_avg": "Peak benchmark",
         "BAT_percustomer_weighted_avg": "Per-customer benchmark",
     }
-    return (
-        cross_summary.melt(
-            id_vars=["group", "customers_weighted"],
-            value_vars=list(component_labels.keys()),
-            var_name="component",
-            value_name="weighted_avg_bat_usd_per_customer_year",
-        )
-        .assign(
-            component_label=lambda d: d["component"].map(component_labels),
-            component_transfer_total_musd_per_year=lambda d: (
-                d["weighted_avg_bat_usd_per_customer_year"] * d["customers_weighted"] / 1e6
-            ),
-        )
+    component_labels = {k: v for k, v in _all_component_labels.items() if k in cross_summary.columns}
+    return cross_summary.melt(
+        id_vars=["group", "customers_weighted"],
+        value_vars=list(component_labels.keys()),
+        var_name="component",
+        value_name="weighted_avg_bat_usd_per_customer_year",
+    ).assign(
+        component_label=lambda d: d["component"].map(component_labels),
+        component_transfer_total_musd_per_year=lambda d: (
+            d["weighted_avg_bat_usd_per_customer_year"] * d["customers_weighted"] / 1e6
+        ),
     )
 
 
@@ -438,15 +448,16 @@ def cairo_tariff_to_urdb(cairo_tariff: dict) -> dict:
 
     The CAIRO internal format stores rates in ``ur_ec_tou_mat`` (a list of
     ``[period, tier, max_usage, units, rate, adj, sell]`` rows) and schedules in
-    ``ur_ec_sched_weekday`` / ``ur_ec_sched_weekend`` (12×24 matrices of
+    ``ur_ec_sched_weekday`` / ``ur_ec_sched_weekend`` (12x24 matrices of
     1-based period indices).
 
     The URDB format stores rates in ``energyratestructure`` (a list-of-lists of
     ``{"rate": ..., "adj": ..., "unit": ...}`` dicts), schedules in
-    ``energyweekdayschedule`` / ``energyweekendschedule`` (12×24, 0-based), and
+    ``energyweekdayschedule`` / ``energyweekendschedule`` (12x24, 0-based), and
     fixed charges in ``fixedchargefirstmeter``.
     """
-    # --- schedules (12×24): CAIRO uses 1-based periods, URDB uses 0-based ---
+
+    # --- schedules (12x24): CAIRO uses 1-based periods, URDB uses 0-based ---
     def _schedule(raw: list[list[int]] | None) -> list[list[int]]:
         if raw is None:
             return [[0] * 24 for _ in range(12)]
@@ -466,8 +477,7 @@ def cairo_tariff_to_urdb(cairo_tariff: dict) -> dict:
         rates_by_period.setdefault(period_0, []).append(entry)
 
     max_period = max(rates_by_period) if rates_by_period else 0
-    rate_structure = [rates_by_period.get(p, [{"rate": 0.0, "adj": 0.0, "unit": "kWh"}])
-                      for p in range(max_period + 1)]
+    rate_structure = [rates_by_period.get(p, [{"rate": 0.0, "adj": 0.0, "unit": "kWh"}]) for p in range(max_period + 1)]
 
     item: dict = {
         "energyweekdayschedule": weekday,
@@ -481,8 +491,18 @@ def cairo_tariff_to_urdb(cairo_tariff: dict) -> dict:
 
 
 _MONTH_ABBR = [
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
 ]
 
 
@@ -504,7 +524,7 @@ def _format_hour_window(hours: list[int]) -> str:
     if not hours:
         return ""
     hrs = sorted(hours)
-    return f"{hrs[0]:02d}:00–{hrs[-1] + 1:02d}:00"
+    return f"{hrs[0]:02d}:00-{hrs[-1] + 1:02d}:00"
 
 
 def summarize_tariff_for_display(tariff_cfg: dict) -> list[dict]:
@@ -537,9 +557,8 @@ def summarize_tariff_for_display(tariff_cfg: dict) -> list[dict]:
 
         n_periods = len(rate_structure)
 
-        # Extract rate for period p (first tier, rate + adj)
-        def _rate(p: int) -> float:
-            tier = rate_structure[p][0]
+        def _rate(p: int, _rs: list = rate_structure) -> float:
+            tier = _rs[p][0]
             return float(tier.get("rate", 0.0)) + float(tier.get("adj", 0.0))
 
         row: dict = {"tariff_key": tariff_key, "fixed_charge_usd_mo": fixed}
@@ -630,16 +649,12 @@ def build_tariff_components(
     )
 
     tariff_components = group_load.merge(
-        cross_summary[["group", "customers_weighted"]].rename(
-            columns={"customers_weighted": "weighted_customers"}
-        ),
+        cross_summary[["group", "customers_weighted"]].rename(columns={"customers_weighted": "weighted_customers"}),
         on="group",
         how="left",
     )
     tariff_components["annual_fixed_charge_collected_usd"] = (
         fixed_monthly * 12 * tariff_components["weighted_customers"]
     )
-    tariff_components["annual_volumetric_charge_collected_usd"] = (
-        vol_rate * tariff_components["annual_load_kwh"]
-    )
+    tariff_components["annual_volumetric_charge_collected_usd"] = vol_rate * tariff_components["annual_load_kwh"]
     return tariff_components

--- a/reports/ny_hp_rates/notebooks/mc_load_year_bat_comp.qmd
+++ b/reports/ny_hp_rates/notebooks/mc_load_year_bat_comp.qmd
@@ -1,0 +1,441 @@
+---
+title: "NY HP Rates: Load-Year BAT & Cross-Subsidy Comparison"
+format:
+  html:
+    page-layout: full
+toc: true
+execute:
+  warning: false
+  message: false
+---
+
+Compare BAT and cross-subsidy results between 2018 and 2025 load years for
+CENHUD and NYSEG. Each run uses the standard CAIRO output schema.
+
+## Setup
+
+```{python}
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+from plotnine import (
+    aes,
+    coord_flip,
+    element_text,
+    facet_grid,
+    facet_wrap,
+    geom_col,
+    geom_hline,
+    geom_text,
+    geom_tile,
+    ggplot,
+    labs,
+    position_dodge,
+    scale_fill_manual,
+    theme,
+    theme_minimal,
+)
+
+for _root in (Path.cwd(), *Path.cwd().parents):
+    _rate_utils = _root / "rate-utils"
+    if (_rate_utils / "plotting_utils.py").is_file():
+        sys.path.insert(0, str(_rate_utils))
+        break
+else:
+    raise FileNotFoundError("Could not locate rate-utils/plotting_utils.py")
+
+from plotting_utils import (
+    build_cross_components,
+    find_latest_run_dir,
+    read_s3_csv,
+    summarize_cross_subsidy,
+)
+
+pd.set_option("display.max_columns", 100)
+```
+
+## Run Configuration
+
+```{python}
+UTILITY_BASES = {
+    ("CENHUD", "2025"): "s3://data.sb/switchbox/cairo/outputs/hp_rates/ny/cenhud/20260305T170623Z/",
+    ("CENHUD", "2018"): "s3://data.sb/switchbox/cairo/outputs/hp_rates/ny/cenhud/20260305T173709Z/",
+    ("NYSEG", "2025"): "s3://data.sb/switchbox/cairo/outputs/hp_rates/ny/nyseg/20260305T170242Z/",
+    ("NYSEG", "2018"): "s3://data.sb/switchbox/cairo/outputs/hp_rates/ny/nyseg/20260305T173330Z/",
+}
+
+RUN_DEFS = {
+    1: {
+        "run_suffix": "run1_up00_precalc__flat",
+        "cost_scope": "delivery",
+        "label": "R1 flat delivery",
+    },
+    2: {
+        "run_suffix": "run2_up00_precalc_supply__flat",
+        "cost_scope": "delivery+supply",
+        "label": "R2 flat delivery+supply",
+    },
+}
+```
+
+```{python}
+run_dirs: dict[tuple[str, str, int], str] = {}
+
+for (utility, load_year), base in UTILITY_BASES.items():
+    slug = f"ny_{utility.lower()}"
+    for run_num, rdef in RUN_DEFS.items():
+        run_name = f"{slug}_{rdef['run_suffix']}"
+        s3_dir = find_latest_run_dir(base, run_name)
+        run_dirs[(utility, load_year, run_num)] = s3_dir
+        print(f"  {utility} {load_year} R{run_num}: {s3_dir}")
+```
+
+## Load BAT & Cross-Subsidy Data
+
+```{python}
+payloads: dict[tuple[str, str, int], dict] = {}
+
+for (utility, load_year, run_num), s3_dir in run_dirs.items():
+    rdef = RUN_DEFS[run_num]
+    metadata = read_s3_csv(f"{s3_dir}/customer_metadata.csv")
+    cross = read_s3_csv(
+        f"{s3_dir}/cross_subsidization/cross_subsidization_BAT_values.csv"
+    )
+
+    cross_summary = summarize_cross_subsidy(cross=cross, metadata=metadata)
+    cross_summary["utility"] = utility
+    cross_summary["load_year"] = load_year
+    cross_summary["run"] = run_num
+    cross_summary["cost_scope"] = rdef["cost_scope"]
+    cross_summary["run_label"] = f"{utility} {load_year} R{run_num}"
+
+    cross_components = build_cross_components(cross_summary)
+    cross_components["utility"] = utility
+    cross_components["load_year"] = load_year
+    cross_components["run"] = run_num
+    cross_components["cost_scope"] = rdef["cost_scope"]
+    cross_components["run_label"] = f"{utility} {load_year} R{run_num}"
+
+    payloads[(utility, load_year, run_num)] = {
+        "metadata": metadata,
+        "cross": cross,
+        "cross_summary": cross_summary,
+        "cross_components": cross_components,
+    }
+
+cross_all = pd.concat(
+    [p["cross_summary"] for p in payloads.values()], ignore_index=True
+)
+components_all = pd.concat(
+    [p["cross_components"] for p in payloads.values()], ignore_index=True
+)
+
+_label_order = (
+    cross_all.sort_values(["utility", "run", "load_year"])["run_label"]
+    .unique()
+    .tolist()
+)
+cross_all["run_label"] = pd.Categorical(
+    cross_all["run_label"], categories=_label_order, ordered=True
+)
+components_all["run_label"] = pd.Categorical(
+    components_all["run_label"], categories=_label_order, ordered=True
+)
+
+print(f"Loaded {len(payloads)} runs ({len(UTILITY_BASES)} utility×load-year combos × {len(RUN_DEFS)} runs each).")
+print(f"Label order: {_label_order}")
+
+print("\nAvailable benchmarks per run (NaN = not in output):")
+for (util, ly, rn), p in payloads.items():
+    cols = [c for c in ["BAT_vol_weighted_avg", "BAT_peak_weighted_avg", "BAT_percustomer_weighted_avg"]
+            if c in p["cross_summary"].columns and p["cross_summary"][c].notna().all()]
+    scope = RUN_DEFS[rn]["cost_scope"]
+    print(f"  {util} {ly} R{rn} ({scope}): {', '.join(c.split('_weighted')[0] for c in cols)}")
+```
+
+## BAT Summary Table
+
+```{python}
+_ALL_BAT_COLS = [
+    "BAT_vol_weighted_avg",
+    "BAT_peak_weighted_avg",
+    "BAT_percustomer_weighted_avg",
+]
+_ALL_RESIDUAL_COLS = {
+    "residual_vol_weighted_avg": "Volumetric",
+    "residual_peak_weighted_avg": "Peak",
+    "residual_percustomer_weighted_avg": "Per-customer",
+}
+BAT_COLS = [c for c in _ALL_BAT_COLS if c in cross_all.columns]
+RESIDUAL_COLS = {k: v for k, v in _ALL_RESIDUAL_COLS.items() if k in cross_all.columns}
+
+_BAT_KEY_MAP = {c: c.replace("BAT_", "").replace("_weighted_avg", "").capitalize()
+                for c in BAT_COLS}
+
+bat_display = [
+    "utility", "load_year", "run", "cost_scope", "group", "customers_weighted",
+    *BAT_COLS,
+    *[c for c in ["Annual_bill_weighted_avg", "Economic_burden_weighted_avg"]
+      if c in cross_all.columns],
+]
+cross_all[bat_display].sort_values(
+    ["utility", "load_year", "run", "group"]
+).reset_index(drop=True)
+```
+
+## BAT Per-Customer by Utility & Load Year
+
+Positive BAT means the group is overpaying relative to cost causation (i.e.
+cross-subsidizing the other group).
+
+```{python}
+# | fig-cap: "BAT per-customer ($/customer-year). Positive = cross-subsidizing others."
+(
+    ggplot(
+        cross_all,
+        aes(x="run_label", y="BAT_percustomer_weighted_avg", fill="group"),
+    )
+    + geom_col(position=position_dodge(width=0.8), width=0.7)
+    + geom_hline(yintercept=0, linetype="dashed", color="gray")
+    + coord_flip()
+    + labs(
+        title="BAT Per-Customer by Utility & Load Year",
+        subtitle="Per-customer benchmark weighted avg ($/customer-year)",
+        x="",
+        y="BAT ($/customer-year)",
+        fill="Group",
+    )
+    + theme_minimal()
+    + theme(figure_size=(10, 5), legend_position="bottom")
+)
+```
+
+## BAT Heatmap: All Benchmarks
+
+```{python}
+#| fig-cap: "Heatmap of BAT across utilities, load years, runs, benchmarks, and groups."
+bat_long = cross_all.melt(
+    id_vars=["utility", "load_year", "run", "cost_scope", "run_label", "group"],
+    value_vars=BAT_COLS,
+    var_name="benchmark_key",
+    value_name="bat_usd",
+)
+bat_long["benchmark"] = bat_long["benchmark_key"].map(_BAT_KEY_MAP)
+bat_long = bat_long.dropna(subset=["bat_usd"])
+bat_long["run_label"] = pd.Categorical(
+    bat_long["run_label"], categories=_label_order, ordered=True
+)
+
+(
+    ggplot(bat_long, aes(x="benchmark", y="run_label", fill="bat_usd"))
+    + geom_tile(color="white", size=0.5)
+    + geom_text(aes(label="bat_usd"), format_string="${:.0f}", size=7)
+    + facet_wrap("~group")
+    + labs(
+        title="BAT Heatmap by Utility, Load Year, Cost Scope, Benchmark",
+        x="Benchmark",
+        y="",
+        fill="BAT ($/cust-yr)",
+    )
+    + theme_minimal()
+    + theme(figure_size=(14, 7), legend_position="right")
+)
+```
+
+## Cross-Subsidy Components ($M/year)
+
+```{python}
+#| fig-cap: "Total cross-subsidy transfer by benchmark component."
+_components_plot = components_all.dropna(subset=["component_transfer_total_musd_per_year"]).copy()
+_components_plot["run_label"] = pd.Categorical(
+    _components_plot["run_label"], categories=_label_order, ordered=True
+)
+
+(
+    ggplot(
+        _components_plot,
+        aes(
+            x="component_label",
+            y="component_transfer_total_musd_per_year",
+            fill="group",
+        ),
+    )
+    + geom_col(position=position_dodge(width=0.8), width=0.7)
+    + facet_wrap("~run_label", ncol=2)
+    + coord_flip()
+    + labs(
+        title="Cross-Subsidy BAT Components ($M/year)",
+        x="Benchmark component",
+        y="Transfer ($M/year)",
+        fill="Group",
+    )
+    + theme_minimal()
+    + theme(figure_size=(14, 12), legend_position="bottom")
+)
+```
+
+## Delta Analysis: 2025 vs 2018
+
+How does switching the load year from 2018 to 2025 change BAT results?
+Computed separately for each run (R1 delivery, R2 delivery+supply).
+
+```{python}
+_delta_metrics = [
+    *BAT_COLS,
+    *[c for c in ["Annual_bill_weighted_avg", "Economic_burden_weighted_avg"]
+      if c in cross_all.columns],
+]
+
+delta_rows = []
+for utility in ["CENHUD", "NYSEG"]:
+    for run_num, rdef in RUN_DEFS.items():
+        for group_name in ["HP", "Non-HP"]:
+            row_2025 = cross_all.query(
+                "utility == @utility and load_year == '2025' "
+                "and run == @run_num and group == @group_name"
+            ).iloc[0]
+            row_2018 = cross_all.query(
+                "utility == @utility and load_year == '2018' "
+                "and run == @run_num and group == @group_name"
+            ).iloc[0]
+            row = {
+                "utility": utility,
+                "run": run_num,
+                "cost_scope": rdef["cost_scope"],
+                "group": group_name,
+            }
+            for col in _delta_metrics:
+                row[f"{col}_delta"] = row_2025[col] - row_2018[col]
+            delta_rows.append(row)
+
+deltas = pd.DataFrame(delta_rows)
+deltas["facet_label"] = deltas["utility"] + " R" + deltas["run"].astype(str)
+_facet_order = (
+    deltas.sort_values(["utility", "run"])["facet_label"].unique().tolist()
+)
+deltas["facet_label"] = pd.Categorical(
+    deltas["facet_label"], categories=_facet_order, ordered=True
+)
+print("Positive delta = higher in 2025 than 2018.")
+deltas
+```
+
+```{python}
+#| fig-cap: "Change in BAT per-customer when switching from 2018 to 2025 load year."
+_bat_delta_cols = [f"{c}_delta" for c in BAT_COLS]
+_bat_delta_map = {f"{c}_delta": _BAT_KEY_MAP[c] for c in BAT_COLS}
+
+delta_long = deltas.melt(
+    id_vars=["utility", "run", "cost_scope", "group", "facet_label"],
+    value_vars=_bat_delta_cols,
+    var_name="benchmark_key",
+    value_name="delta_usd",
+)
+delta_long["benchmark"] = delta_long["benchmark_key"].map(_bat_delta_map)
+delta_long = delta_long.dropna(subset=["delta_usd"])
+delta_long["facet_label"] = pd.Categorical(
+    delta_long["facet_label"], categories=_facet_order, ordered=True
+)
+
+(
+    ggplot(
+        delta_long,
+        aes(x="benchmark", y="delta_usd", fill="group"),
+    )
+    + geom_col(position=position_dodge(width=0.8), width=0.7)
+    + geom_hline(yintercept=0, linetype="dashed", color="gray")
+    + facet_wrap("~facet_label", ncol=2)
+    + coord_flip()
+    + labs(
+        title="BAT Delta: 2025 minus 2018 ($/customer-year)",
+        subtitle="Positive = 2025 load year increases BAT",
+        x="Benchmark",
+        y="Δ BAT ($/customer-year)",
+        fill="Group",
+    )
+    + theme_minimal()
+    + theme(figure_size=(12, 6), legend_position="bottom")
+)
+```
+
+## Marginal vs Residual Cost Composition
+
+```{python}
+#| fig-cap: "Per-customer cost split between marginal (economic burden) and residual allocation."
+per_customer_long = (
+    cross_all.melt(
+        id_vars=["run_label", "group", "Economic_burden_weighted_avg"],
+        value_vars=list(RESIDUAL_COLS.keys()),
+        var_name="residual_key",
+        value_name="residual_usd_per_customer",
+    )
+    .assign(benchmark=lambda d: d["residual_key"].map(RESIDUAL_COLS))
+    .melt(
+        id_vars=["run_label", "group", "benchmark"],
+        value_vars=[
+            "Economic_burden_weighted_avg",
+            "residual_usd_per_customer",
+        ],
+        var_name="cost_source_key",
+        value_name="usd_per_customer",
+    )
+    .assign(
+        cost_source=lambda d: d["cost_source_key"].map(
+            {
+                "Economic_burden_weighted_avg": "Marginal (economic burden)",
+                "residual_usd_per_customer": "Residual allocation",
+            }
+        )
+    )
+)
+per_customer_long["cost_source"] = pd.Categorical(
+    per_customer_long["cost_source"],
+    categories=["Residual allocation", "Marginal (economic burden)"],
+    ordered=True,
+)
+per_customer_long = per_customer_long.dropna(subset=["usd_per_customer"])
+per_customer_long["run_label"] = pd.Categorical(
+    per_customer_long["run_label"], categories=_label_order, ordered=True
+)
+
+(
+    ggplot(
+        per_customer_long,
+        aes(x="group", y="usd_per_customer", fill="cost_source"),
+    )
+    + geom_col(position="stack", width=0.65)
+    + scale_fill_manual(
+        values={
+            "Marginal (economic burden)": "#00BFC4",
+            "Residual allocation": "#F8766D",
+        },
+        breaks=["Marginal (economic burden)", "Residual allocation"],
+    )
+    + facet_grid("run_label ~ benchmark")
+    + labs(
+        title="Cost Composition: Marginal vs Residual ($/customer/year)",
+        x="Customer group",
+        y="$/customer/year",
+        fill="Cost source",
+    )
+    + theme_minimal()
+    + theme(figure_size=(12, 10), legend_position="bottom")
+)
+```
+
+## Customer-Count Comparison
+
+```{python}
+customer_counts = (
+    cross_all[["utility", "load_year", "run", "cost_scope", "group", "customers_weighted"]]
+    .sort_values(["utility", "load_year", "run", "group"])
+    .reset_index(drop=True)
+)
+customer_counts["customers_weighted"] = customer_counts[
+    "customers_weighted"
+].map("{:,.0f}".format)
+customer_counts
+```


### PR DESCRIPTION
## Summary

- Add `mc_load_year_bat_comp.qmd` notebook comparing BAT and cross-subsidization results between 2018 and 2025 load years for NY utilities (CENHUD, NYSEG), scoped to runs 1 (delivery) and 2 (delivery+supply).
- Make `summarize_cross_subsidy`, `summarize_cross_subsidy_by_heating_type`, and `build_cross_components` in `plotting_utils.py` skip missing columns gracefully, so NY outputs (which may lack `BAT_peak`) work alongside RI outputs (which have all three benchmarks).
- Fix pre-existing ruff lints in `plotting_utils.py` (unused variable, ambiguous unicode chars, loop variable capture).

## Notebook sections

- **BAT Summary Table** — all metrics by utility, load year, run, group
- **BAT Per-Customer bar chart** — per-customer benchmark comparison
- **BAT Heatmap** — all available benchmarks in a tile chart
- **Cross-Subsidy Components** — total transfer ($M/year) by benchmark component
- **Delta Analysis** — 2025 minus 2018 per utility and run, isolating load-year effect
- **Marginal vs Residual Cost Composition** — stacked bars splitting marginal vs residual
- **Customer-Count Comparison** — weighted customer counts across runs

## Test plan

- [ ] Re-run notebook top-to-bottom with valid S3 credentials
- [ ] Verify diagnostic output correctly identifies which benchmarks each run has
- [ ] Confirm NaN benchmarks are excluded from charts (no phantom zero bars)
- [ ] Check that CENHUD 2018 path is updated to the correct timestamp before merging

Made with [Cursor](https://cursor.com)