### PR TITLE
Add `INCLUDE_LMI_DISCOUNT` toggle for NY report

### DIFF
--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -91,8 +91,10 @@ def add_matplotlib_footnote(
     fig: Figure,
     note: str | None,
     *,
-    width: int = 88,
-    fontsize: int = 7,
+    width: int = 96,
+    fontsize: int = 12,
+    x: float = 0.02,
+    ha: str = "left",
 ) -> None:
     """Append wrapped *note* below the figure (matplotlib only)."""
     if not note:
@@ -100,8 +102,8 @@ def add_matplotlib_footnote(
     lines = textwrap.wrap(note, width=width) or [""]
     wrapped = "\n".join(lines)
     extra = 0.022 * max(0, len(lines) - 1)
-    fig.subplots_adjust(bottom=min(0.32, 0.11 + extra))
-    fig.text(0.5, 0.01, wrapped, fontsize=fontsize, ha="center", va="bottom")
+    fig.subplots_adjust(bottom=min(0.36, 0.12 + extra))
+    fig.text(x, 0.01, wrapped, fontsize=fontsize, ha=ha, va="bottom")
 ```
 
 ## Parameters
@@ -207,11 +209,11 @@ LMI_ENROLLED_BILL_COLS = lmi_enrolled_bill_cols(LMI_CURRENT_ENROLLMENT_PCT)
 INCLUDE_LMI_DISCOUNT = True  # False = undiscounted (legacy)
 ACTIVE_BILL_COLS = LMI_ENROLLED_BILL_COLS if INCLUDE_LMI_DISCOUNT else LMI_BILL_COLS
 LMI_ENROLLED_CAPTION = (
-    f"Assumes ~{LMI_CURRENT_ENROLLMENT_PCT}% of LMI households receive discounts before and after HP switch."
+    f"* Assumes ~{LMI_CURRENT_ENROLLMENT_PCT}% of LMI households receive discounts before and after HP switch."
 )
 LMI_CAPTION_SUFFIX = (
     LMI_ENROLLED_CAPTION if INCLUDE_LMI_DISCOUNT else
-    "Undiscounted annual bills (LMI discount enrollment not modeled)."
+    "* Undiscounted annual bills (LMI discount enrollment not modeled)."
 )
 report_vars["lmi_caption_suffix"] = LMI_CAPTION_SUFFIX
 report_vars["lmi_enrolled_caption"] = LMI_ENROLLED_CAPTION
@@ -1871,7 +1873,7 @@ def _lmi_delta_state(
 
 
 delta_state_lmi_enrolled = _lmi_delta_state(
-    bills_current, bills_hp, LMI_ENROLLED_BILL_COLS, LMI_ENROLLED_BILL_COLS,
+    bills_current, bills_hp, ACTIVE_BILL_COLS, ACTIVE_BILL_COLS,
 )
 
 natgas_state_lmi_enrolled = (
@@ -1890,16 +1892,21 @@ report_vars["pct_natgas_lose_1k_default_lmi40"] = _lmi40_def_lose_1k / _lmi40_de
 #| label: fig-quadrant-bar-natgas-state-state-lmi-current
 #| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide)."
 
+_title_natgas_state_lmi: list[tuple[str, str]] = [
+    ("How bills would change for ", "#000000"),
+    ("natural gas", "#7A8A10"),
+    (" heated homes after switching to ", "#000000"),
+    ("heat pumps", "#c47600"),
+]
+if INCLUDE_LMI_DISCOUNT:
+    _title_natgas_state_lmi.append(
+        (f"\n(~{LMI_CURRENT_ENROLLMENT_PCT}% LMI discounts)", "#000000"),
+    )
+
 plot_quadrant_bar(
     [("Natural gas", natgas_state_lmi_enrolled)],
-    title_parts=[
-        ("How bills would change for ", "#000000"),
-        ("natural gas", "#7A8A10"),
-        (" heated homes after switching to ", "#000000"),
-        ("heat pumps", "#c47600"),
-        (f"\n(~{LMI_CURRENT_ENROLLMENT_PCT}% LMI discounts)", "#000000"),
-    ],
-    footnote=LMI_ENROLLED_CAPTION,
+    title_parts=_title_natgas_state_lmi,
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4584,7 +4591,7 @@ comes from `bills_hprate_hp` (`RUN_HPRATE_HP`) instead of `bills_hp` (runs 3+4).
 #| label: compute-lmi-switch-deltas-state
 
 delta_switch_state_lmi_enrolled = _lmi_delta_state(
-    bills_current, bills_hprate_hp, LMI_ENROLLED_BILL_COLS, LMI_ENROLLED_BILL_COLS,
+    bills_current, bills_hprate_hp, ACTIVE_BILL_COLS, ACTIVE_BILL_COLS,
 )
 delta_switch_state_lmi_full = _lmi_delta_state(
     bills_current, bills_hprate_hp, LMI_40_BILL_COLS, LMI_100_BILL_COLS,
@@ -4628,7 +4635,7 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_ENROLLED_CAPTION,
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4737,7 +4744,7 @@ parquet) to align with the primary reference chart.
 #| label: compute-deltas-natgas-switch-ehrate-lmi-enrolled
 
 delta_switch_state_ehrate_lmi_enrolled = _lmi_delta_state(
-    bills_current, bills_ehrate_hp, LMI_ENROLLED_BILL_COLS, LMI_ENROLLED_BILL_COLS,
+    bills_current, bills_ehrate_hp, ACTIVE_BILL_COLS, ACTIVE_BILL_COLS,
 )
 natgas_switch_ehrate_state_lmi_enrolled = (
     delta_switch_state_ehrate_lmi_enrolled
@@ -4768,7 +4775,7 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_ENROLLED_CAPTION,
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -5388,12 +5395,20 @@ print(f"HP + seasonal rates: {above_hp_seasonal:.1f}% above 6% | {below_hp_seaso
 ```{python}
 #| label: burden-bar-helper
 
-BURDEN_SCENARIO_LABELS = [
-    f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-    f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-    f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-    "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
-]
+if INCLUDE_LMI_DISCOUNT:
+    BURDEN_SCENARIO_LABELS = [
+        f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+        f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+        f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
+    ]
+else:
+    BURDEN_SCENARIO_LABELS = [
+        "Current HVAC\nDefault Rates\n(undiscounted bills)",
+        "Heat Pump\nDefault Rates\n(undiscounted bills)",
+        "Heat Pump\nHP Seasonal Rates\n(undiscounted bills)",
+        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
+    ]
 BURDEN_SEGMENT_ORDER = ["Above 6%", "Below 6%"]
 BURDEN_COLORS = {
     "Above 6%": SB_COLORS["carrot"],
@@ -5472,13 +5487,13 @@ Energy burdens in the first three scenarios use the bill columns for
 #| label: burden-compute-lmi-current
 
 below_current_lmi40, above_current_lmi40 = burden_shares(
-    bills_current, cohort_bldg_ids, income_df, bill_cols=LMI_ENROLLED_BILL_COLS,
+    bills_current, cohort_bldg_ids, income_df, bill_cols=ACTIVE_BILL_COLS,
 )
 below_hp_default_lmi40, above_hp_default_lmi40 = burden_shares(
-    bills_hp, cohort_bldg_ids, income_df, bill_cols=LMI_ENROLLED_BILL_COLS,
+    bills_hp, cohort_bldg_ids, income_df, bill_cols=ACTIVE_BILL_COLS,
 )
 below_hp_seasonal_lmi40, above_hp_seasonal_lmi40 = burden_shares(
-    bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_ENROLLED_BILL_COLS,
+    bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=ACTIVE_BILL_COLS,
 )
 below_hp_seasonal_lmi100, above_hp_seasonal_lmi100 = burden_shares(
     bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_100_BILL_COLS,
@@ -5504,7 +5519,8 @@ _p_burden_lmi = plot_burden_bar(
 _fig_burden_lmi = _p_burden_lmi.draw()
 add_matplotlib_footnote(
     _fig_burden_lmi,
-    LMI_ENROLLED_CAPTION + " Rightmost bar: universal 100% enrollment (_lmi_100 columns) on the HP seasonal rate.",
+    LMI_CAPTION_SUFFIX
+    + " Rightmost bar: universal 100% enrollment (_lmi_100 columns) on the HP seasonal rate.",
 )
 display_svg(_fig_burden_lmi)
 ```
@@ -5523,9 +5539,9 @@ for code in UTIL_ORDER_CODES:
         continue
     util_income = income_df.filter(pl.col(BLDG_ID).is_in(util_bldg_ids))
     burden_by_utility[code] = {
-        "current": burden_shares(bills_current, util_bldg_ids, util_income, bill_cols=LMI_ENROLLED_BILL_COLS),
-        "hp_default": burden_shares(bills_hp, util_bldg_ids, util_income, bill_cols=LMI_ENROLLED_BILL_COLS),
-        "hp_seasonal": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_ENROLLED_BILL_COLS),
+        "current": burden_shares(bills_current, util_bldg_ids, util_income, bill_cols=ACTIVE_BILL_COLS),
+        "hp_default": burden_shares(bills_hp, util_bldg_ids, util_income, bill_cols=ACTIVE_BILL_COLS),
+        "hp_seasonal": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=ACTIVE_BILL_COLS),
         "hp_seasonal_lmi100": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_100_BILL_COLS),
     }
 
@@ -5546,12 +5562,20 @@ _BURDEN_LABEL_ABOVE = "ENERGY BURDEN ABOVE 6%"
 _BURDEN_LABEL_BELOW = "ENERGY BURDEN BELOW 6%"
 
 _BURDEN_UTIL_SCENARIO_KEYS = ["current", "hp_default", "hp_seasonal", "hp_seasonal_lmi100"]
-_BURDEN_UTIL_SCENARIO_LABELS = [
-    f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-    f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-    f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-    "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
-]
+if INCLUDE_LMI_DISCOUNT:
+    _BURDEN_UTIL_SCENARIO_LABELS = [
+        f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+        f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+        f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
+    ]
+else:
+    _BURDEN_UTIL_SCENARIO_LABELS = [
+        "Current HVAC\nDefault Rates\n(undiscounted bills)",
+        "Heat Pump\nDefault Rates\n(undiscounted bills)",
+        "Heat Pump\nHP Seasonal Rates\n(undiscounted bills)",
+        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
+    ]
 
 
 def plot_burden_bar_by_utility(

--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -208,15 +208,11 @@ def lmi_enrolled_bill_cols(pct: int) -> list[str]:
 LMI_ENROLLED_BILL_COLS = lmi_enrolled_bill_cols(LMI_CURRENT_ENROLLMENT_PCT)
 INCLUDE_LMI_DISCOUNT = True  # False = undiscounted (legacy)
 ACTIVE_BILL_COLS = LMI_ENROLLED_BILL_COLS if INCLUDE_LMI_DISCOUNT else LMI_BILL_COLS
-LMI_ENROLLED_CAPTION = (
-    f"* Assumes ~{LMI_CURRENT_ENROLLMENT_PCT}% of LMI households receive discounts before and after HP switch."
-)
-LMI_CAPTION_SUFFIX = (
-    LMI_ENROLLED_CAPTION if INCLUDE_LMI_DISCOUNT else
-    "* Undiscounted annual bills (LMI discount enrollment not modeled)."
-)
-report_vars["lmi_caption_suffix"] = LMI_CAPTION_SUFFIX
-report_vars["lmi_enrolled_caption"] = LMI_ENROLLED_CAPTION
+# Figure captions (#| fig-cap) cannot depend on the flags above. Bill-impact figures
+# spell out the LMI assumption in the fig-cap text; commented ``# #| fig-cap:``
+# alternatives (no LMI / ~40% / ~100%) sit under each affected chunk. After changing
+# ``INCLUDE_LMI_DISCOUNT`` or ``LMI_CURRENT_ENROLLMENT_PCT`` (40 vs 100), update those
+# fig-caps to match so prose matches the bill columns in the plots.
 UTIL_NAMES = {  # state-dependent: swap when switching states
     "cenhud": "Central Hudson",
     "coned": "Con Edison",
@@ -1889,7 +1885,11 @@ report_vars["pct_natgas_lose_1k_default_lmi40"] = _lmi40_def_lose_1k / _lmi40_de
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-state-state-lmi-current
-#| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide)."
+#| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see ``INCLUDE_LMI_DISCOUNT`` / ``LMI_CURRENT_ENROLLMENT_PCT`` in chunk ``constants``):
+# #| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 _title_natgas_state_lmi: list[tuple[str, str]] = [
     ("How bills would change for ", "#000000"),
@@ -1905,13 +1905,16 @@ if INCLUDE_LMI_DISCOUNT:
 plot_quadrant_bar(
     [("Natural gas", natgas_state_lmi_enrolled)],
     title_parts=_title_natgas_state_lmi,
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-oil-propane-state
-#| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide)."
+#| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [("Oil / propane", oil_propane_state)],
@@ -1923,13 +1926,16 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-state
-#| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide)."
+#| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [("Electric resistance", elec_resistance_state)],
@@ -1939,7 +1945,6 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4436,7 +4441,11 @@ display_svg(fig_3bar)
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-switch-hprate-by-utility
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility. Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility. Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar_by_utility(
     delta_state, delta_switch_state,
@@ -4448,7 +4457,6 @@ plot_quadrant_bar_by_utility(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4476,7 +4484,11 @@ if INCLUDE_TOU:
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-tou-state
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide)."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 if INCLUDE_TOU:
     _tou_quadrant_fig = plot_quadrant_bar(
@@ -4491,7 +4503,6 @@ if INCLUDE_TOU:
             (" heated homes after switching to ", "#000000"),
             ("heat pumps", "#c47600"),
         ],
-        footnote=LMI_CAPTION_SUFFIX,
     )
     _q_fair = quadrant_pcts(natgas_switch_state)
     _q_tou = quadrant_pcts(natgas_tou_state)
@@ -4621,7 +4632,11 @@ report_vars["pct_natgas_save_1k_hprate_lmi_full"] = _lmif_save_1k / _lmif_total
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-switch-hprate-state-lmi-current
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide)."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [
@@ -4634,13 +4649,16 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-oil-propane-switch-hprate-state
-#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide)."
+#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [
@@ -4655,13 +4673,16 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-oil-propane-switch-hprate-by-utility
-#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility."
+#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility. Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility. Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar_by_utility(
     delta_state, delta_switch_state,
@@ -4675,13 +4696,16 @@ plot_quadrant_bar_by_utility(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-switch-hprate-state
-#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide)."
+#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [
@@ -4694,13 +4718,16 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-switch-hprate-by-utility
-#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility."
+#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility. Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility. Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar_by_utility(
     delta_state, delta_switch_state,
@@ -4712,7 +4739,6 @@ plot_quadrant_bar_by_utility(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4760,7 +4786,11 @@ report_vars["pct_natgas_lose_1k_ehrate_lmi40"] = _lmi40_eh_lose_1k / _lmi40_eh_t
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-switch-ehrate-state-lmi-current
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide)."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [
@@ -4774,7 +4804,6 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4826,7 +4855,11 @@ report_vars["mean_monthly_er_stay_delta_ehrate"] = (
 
 ```{python}
 #| label: fig-hist-elec-resistance-stay-ehrate-state
-#| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide."
+#| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide. Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide. Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 _annual_er_stay = (
     elec_resistance_stay_ehrate_state
@@ -4861,7 +4894,6 @@ _p_er_hist = (
     )
 )
 _fig_er_hist = _p_er_hist.draw()
-add_matplotlib_footnote(_fig_er_hist, LMI_CAPTION_SUFFIX)
 display_svg(_fig_er_hist)
 ```
 
@@ -4932,7 +4964,11 @@ fossil_hprate_state = (
 
 ```{python}
 #| label: fig-bill-change-fossil-ehrate-state
-#| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only."
+#| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only. Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only. Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 REBAL_3_COLORS = {
     "increase < $5/mo": "#ef9a9a",
@@ -5048,7 +5084,6 @@ p = (
 for _a in _annotations:
     p = p + _a
 _fig_fossil_eh = p.draw()
-add_matplotlib_footnote(_fig_fossil_eh, LMI_CAPTION_SUFFIX)
 display_svg(_fig_fossil_eh)
 ```
 
@@ -5154,7 +5189,11 @@ report_vars["mean_er_switch_delta_ehrate"] = _weighted_mean(
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-switch-three-regimes-state
-#| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after."
+#| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after. Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after. Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after. Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 plot_quadrant_bar(
     [
@@ -5168,7 +5207,6 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
-    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -5205,7 +5243,11 @@ delta_rebal_state = annual_before_rebal_state.join(annual_after_rebal_state, on=
 
 ```{python}
 #| label: fig-bill-change-non-hp-rebal-state
-#| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide)."
+#| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# Fig-cap LMI variants (see chunk ``constants``):
+# #| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+# #| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide). Assumes ~40% of LMI households receive discounts before and after HP switch."
+# #| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide). Assumes ~100% of LMI households receive discounts before and after HP switch."
 
 REBAL_3_COLORS = {
     "bill decrease": "#81c784",
@@ -5290,7 +5332,6 @@ p = (
 for _a in _annotations:
     p = p + _a
 _fig_rebal = p.draw()
-add_matplotlib_footnote(_fig_rebal, LMI_CAPTION_SUFFIX)
 display_svg(_fig_rebal)
 ```
 

--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 from pathlib import Path
 import math
-import textwrap
 
 import polars as pl
 from great_tables import GT
@@ -85,25 +84,6 @@ def _weighted_percentile(df: pl.DataFrame, col: str, w_col: str, q: float) -> fl
 def _weighted_mean(df: pl.DataFrame, col: str, w_col: str) -> float:
     """Weighted arithmetic mean."""
     return float((df[col] * df[w_col]).sum() / df[w_col].sum())
-
-
-def add_matplotlib_footnote(
-    fig: Figure,
-    note: str | None,
-    *,
-    width: int = 96,
-    fontsize: int = 12,
-    x: float = 0.02,
-    ha: str = "left",
-) -> None:
-    """Append wrapped *note* below the figure (matplotlib only)."""
-    if not note:
-        return
-    lines = textwrap.wrap(note, width=width) or [""]
-    wrapped = "\n".join(lines)
-    extra = 0.022 * max(0, len(lines) - 1)
-    fig.subplots_adjust(bottom=min(0.36, 0.12 + extra))
-    fig.text(x, 0.01, wrapped, fontsize=fontsize, ha=ha, va="bottom")
 ```
 
 ## Parameters
@@ -503,7 +483,23 @@ def bill_components_for_scenario(
     bills_lf: pl.LazyFrame,
     utility: str | None = None,
 ) -> pl.DataFrame:
-    """Extract annual bill components (electric + gas + delivered fuels) from master bills."""
+    """Extract annual bill components (electric + gas + delivered fuels) from master bills.
+
+    ``energy_total`` here is deliberately the **undiscounted** sum of the
+    per-component columns (fixed + volumetric delivery + supply + gas/oil/propane),
+    so it matches the visible total of stacked-bar charts that plot these
+    components directly. It does NOT equal ``energy_total_bill`` from the master
+    bills after ingest (which was rewritten to follow ``ACTIVE_BILL_COLS`` and is
+    LMI-aware when ``INCLUDE_LMI_DISCOUNT`` is on).
+
+    For LMI-aware bill-change deltas, use ``delta_state`` /
+    ``delta_state_lmi_enrolled`` (which pull ``energy_total_bill`` directly),
+    not the frames returned by this function.
+
+    Callers that publish ``energy_total`` into prose via ``report_vars`` must
+    ensure the chosen building has no LMI credit; otherwise the narrative total
+    will disagree with the LMI-aware quadrant charts surrounding it.
+    """
     filtered = bills_lf.filter(pl.col("month") == ANNUAL_MONTH)
     if utility is not None:
         filtered = filtered.filter(pl.col("sb.electric_utility") == utility)
@@ -525,6 +521,9 @@ def bill_components_for_scenario(
                 + pl.col("oil_total_bill")
                 + pl.col("propane_total_bill")
             ).alias("energy_total"),
+            pl.col("elec_total_bill"),
+            pl.col("elec_total_bill_lmi_40"),
+            pl.col("elec_total_bill_lmi_100"),
             "heats_with_natgas",
             "in.hvac_cooling_partial_space_conditioning",
         )
@@ -738,12 +737,26 @@ hp_same_bldgs_state = (
 assert not hp_same_bldgs_state.is_empty(), "No matching buildings statewide (HP)"
 
 median_bldg_id_state = 328510                                                    # <3>
-median_current_state = (                                                         # <3>
-    natgas_current_state                                                         # <3>
-    .filter(pl.col(BLDG_ID) == median_bldg_id_state)                            # <3>
-    .select(SELECT_COLS)                                                         # <3>
-)                                                                                # <3>
-assert len(median_current_state) == 1, f"Hardcoded bldg {median_bldg_id_state} not found in natgas pool"
+_median_raw = (
+    natgas_current_state
+    .filter(pl.col(BLDG_ID) == median_bldg_id_state)
+)
+assert len(_median_raw) == 1, f"Hardcoded bldg {median_bldg_id_state} not found in natgas pool"
+# Guards the chart/prose consistency described in ``bill_components_for_scenario``:
+# ``energy_total`` (sum of components) must equal ``elec_total_bill_lmi_*`` for
+# this building, otherwise the LMI-aware quadrant-chart narrative will disagree
+# with the bill-components narrative for the same household.
+_median_raw_row = _median_raw.row(0, named=True)
+_median_lmi_credit = _median_raw_row["elec_total_bill"] - _median_raw_row[
+    "elec_total_bill_lmi_40" if LMI_CURRENT_ENROLLMENT_PCT == 40 else "elec_total_bill_lmi_100"
+]
+assert abs(_median_lmi_credit) < 1.0, (
+    f"Representative bldg {median_bldg_id_state} has an LMI credit of "
+    f"${_median_lmi_credit:.2f}. ``median_energy_total`` uses the undiscounted "
+    f"component sum, so prose will disagree with the LMI-aware quadrant charts. "
+    f"Pick a non-LMI representative building or reconcile the narratives."
+)
+median_current_state = _median_raw.select(SELECT_COLS)
 median_hp_state = (
     hp_same_bldgs_state
     .filter(pl.col(BLDG_ID) == median_bldg_id_state)
@@ -1340,7 +1353,6 @@ def plot_quadrant_bar(
     rows: list[tuple[str, pl.DataFrame]],
     title: str = "How bills would change after switching to heat pumps:",
     title_parts: list[tuple[str, str]] | None = None,
-    footnote: str | None = None,
 ) -> ggplot | Figure:
     """Horizontal stacked bar(s) showing quadrant proportions.
 
@@ -1488,8 +1500,6 @@ def plot_quadrant_bar(
             x_pos = bb.transformed(fig.transFigure.inverted()).x1
             if i < len(title_parts) - 1:
                 x_pos += space_fig
-        if footnote:
-            add_matplotlib_footnote(fig, footnote)
         return fig
 
     return p
@@ -1509,7 +1519,6 @@ def plot_quadrant_bar_by_utility(
     fuel_filter: pl.Expr,
     title_parts: list[tuple[str, str]],
     scenario_labels: tuple[str, str] = ("Default rate", "HP seasonal rate"),
-    footnote: str | None = None,
 ) -> None:
     """Grouped quadrant bars for each utility in a single tall figure.
 
@@ -1582,9 +1591,10 @@ def plot_quadrant_bar_by_utility(
             ax.barh(bp, width, left=left, height=_QBU_BAR_HEIGHT,
                     color=QUADRANT_COLORS[q], edgecolor="none", align="edge")
             if width >= 3:
+                ax.text(left + width / 2, bp + _QBU_BAR_HEIGHT / 2, f"{width:.1f}%",
                         ha="center", va="center", color="white",
                         fontsize=10, fontweight="bold", fontfamily="IBM Plex Sans")
-                        fontsize=10, fontweight="bold", fontfamily="IBM Plex Sans")
+            left += width
 
     for bp, label in zip(bar_positions, bar_scenario_labels):
         ax.text(101, bp + _QBU_BAR_HEIGHT / 2, label,
@@ -1602,7 +1612,7 @@ def plot_quadrant_bar_by_utility(
             mid = cum + first_pct[q] / 2
             cum += first_pct[q]
             if first_pct[q] < 2:
-            if first_pct[q] < 2:
+                continue
             ax.text(mid, label_y, QUADRANT_LABELS[q],
                     ha="center", va="bottom", fontsize=8,
                     fontweight="bold", color=QUADRANT_COLORS[q],
@@ -1634,8 +1644,6 @@ def plot_quadrant_bar_by_utility(
         if i < len(title_parts) - 1:
             x_pos += space_fig
 
-    if footnote:
-        add_matplotlib_footnote(fig, footnote)
     display_svg(fig)
 ```
 

--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import math
+import textwrap
 
 import polars as pl
 from great_tables import GT
@@ -84,6 +85,23 @@ def _weighted_percentile(df: pl.DataFrame, col: str, w_col: str, q: float) -> fl
 def _weighted_mean(df: pl.DataFrame, col: str, w_col: str) -> float:
     """Weighted arithmetic mean."""
     return float((df[col] * df[w_col]).sum() / df[w_col].sum())
+
+
+def add_matplotlib_footnote(
+    fig: Figure,
+    note: str | None,
+    *,
+    width: int = 88,
+    fontsize: int = 7,
+) -> None:
+    """Append wrapped *note* below the figure (matplotlib only)."""
+    if not note:
+        return
+    lines = textwrap.wrap(note, width=width) or [""]
+    wrapped = "\n".join(lines)
+    extra = 0.022 * max(0, len(lines) - 1)
+    fig.subplots_adjust(bottom=min(0.32, 0.11 + extra))
+    fig.text(0.5, 0.01, wrapped, fontsize=fontsize, ha="center", va="bottom")
 ```
 
 ## Parameters
@@ -166,11 +184,37 @@ BLDG_ID = "bldg_id"
 HEATING_TYPE_COL = "postprocess_group.heating_type"
 INCOME_COL = "in.representative_income"
 BURDEN_THRESHOLD = 0.06
+# 40 or 100 only — selects ``_lmi_40`` vs ``_lmi_100`` electric+gas bill columns when LMI is modeled.
 LMI_CURRENT_ENROLLMENT_PCT = 40
 report_vars["lmi_current_enrollment_pct"] = LMI_CURRENT_ENROLLMENT_PCT
 LMI_BILL_COLS = ["elec_total_bill", "gas_total_bill", "oil_total_bill", "propane_total_bill"]
 LMI_40_BILL_COLS = ["elec_total_bill_lmi_40", "gas_total_bill_lmi_40", "oil_total_bill", "propane_total_bill"]
 LMI_100_BILL_COLS = ["elec_total_bill_lmi_100", "gas_total_bill_lmi_100", "oil_total_bill", "propane_total_bill"]
+_LMI_ENROLLMENT_ALLOWED = (40, 100)
+
+
+def lmi_enrolled_bill_cols(pct: int) -> list[str]:
+    """Map modeled LMI enrollment rate to parquet bill columns (electric + gas tiers)."""
+    if pct == 40:
+        return LMI_40_BILL_COLS
+    if pct == 100:
+        return LMI_100_BILL_COLS
+    msg = f"LMI_CURRENT_ENROLLMENT_PCT must be one of {_LMI_ENROLLMENT_ALLOWED}, got {pct!r}"
+    raise ValueError(msg)
+
+
+LMI_ENROLLED_BILL_COLS = lmi_enrolled_bill_cols(LMI_CURRENT_ENROLLMENT_PCT)
+INCLUDE_LMI_DISCOUNT = True  # False = undiscounted (legacy)
+ACTIVE_BILL_COLS = LMI_ENROLLED_BILL_COLS if INCLUDE_LMI_DISCOUNT else LMI_BILL_COLS
+LMI_ENROLLED_CAPTION = (
+    f"Assumes ~{LMI_CURRENT_ENROLLMENT_PCT}% of LMI households receive discounts before and after HP switch."
+)
+LMI_CAPTION_SUFFIX = (
+    LMI_ENROLLED_CAPTION if INCLUDE_LMI_DISCOUNT else
+    "Undiscounted annual bills (LMI discount enrollment not modeled)."
+)
+report_vars["lmi_caption_suffix"] = LMI_CAPTION_SUFFIX
+report_vars["lmi_enrolled_caption"] = LMI_ENROLLED_CAPTION
 UTIL_NAMES = {  # state-dependent: swap when switching states
     "cenhud": "Central Hudson",
     "coned": "Con Edison",
@@ -225,13 +269,25 @@ ResStock metadata columns — across all NY utilities.
 ```{python}
 #| label: supply-passthrough-helper
 
+
+def apply_energy_total_bill(lf: pl.LazyFrame) -> pl.LazyFrame:
+    """Rewrite energy_total_bill using ACTIVE_BILL_COLS.
+
+    Applied symmetrically to all bills frames so that bill-change deltas
+    use matching discount semantics on both sides of the join.
+    """
+    return lf.with_columns(
+        pl.sum_horizontal([pl.col(c) for c in ACTIVE_BILL_COLS]).alias("energy_total_bill")
+    )
+
+
 def apply_supply_passthrough(
     proposed_lf: pl.LazyFrame,
     baseline_lf: pl.LazyFrame,
 ) -> pl.LazyFrame:
     """Replace supply columns in proposed with baseline's supply (same buildings, same kWh).
 
-    Recomputes elec_total_bill, energy_total_bill, and LMI electric columns.
+    Recomputes elec_total_bill and LMI electric columns.
     Gas/oil/propane and delivery columns are untouched.
 
     LMI credits are recovered from the proposed data itself (before patching)
@@ -266,12 +322,6 @@ def apply_supply_passthrough(
             ).alias("elec_total_bill"),
         )
         .with_columns(
-            (
-                pl.col("elec_total_bill")
-                + pl.col("gas_total_bill")
-                + pl.col("oil_total_bill")
-                + pl.col("propane_total_bill")
-            ).alias("energy_total_bill"),
             (pl.col("elec_total_bill") - pl.col("_credit_40"))
             .clip(lower_bound=0.0)
             .alias("elec_total_bill_lmi_40"),
@@ -355,12 +405,6 @@ def apply_supply_passthrough_tou(
             ).alias("elec_total_bill"),
         )
         .with_columns(
-            (
-                pl.col("elec_total_bill")
-                + pl.col("gas_total_bill")
-                + pl.col("oil_total_bill")
-                + pl.col("propane_total_bill")
-            ).alias("energy_total_bill"),
             (pl.col("elec_total_bill") - pl.col("_credit_40"))
             .clip(lower_bound=0.0)
             .alias("elec_total_bill_lmi_40"),
@@ -435,6 +479,15 @@ if SUPPLY_PASSTHROUGH:
     bills_hprate_hp = apply_supply_passthrough(bills_hprate_hp, bills_hp)
     bills_ehrate_current = apply_supply_passthrough(bills_ehrate_current, bills_current)
     bills_ehrate_hp = apply_supply_passthrough(bills_ehrate_hp, bills_hp)
+
+bills_current = apply_energy_total_bill(bills_current)
+bills_hp = apply_energy_total_bill(bills_hp)
+bills_hprate_current = apply_energy_total_bill(bills_hprate_current)
+bills_hprate_hp = apply_energy_total_bill(bills_hprate_hp)
+if bills_tou_hp is not None:
+    bills_tou_hp = apply_energy_total_bill(bills_tou_hp)
+bills_ehrate_current = apply_energy_total_bill(bills_ehrate_current)
+bills_ehrate_hp = apply_energy_total_bill(bills_ehrate_hp)
 ```
 
 ## Bill components: how energy bills change after switching
@@ -466,7 +519,14 @@ def bill_components_for_scenario(
             pl.col("gas_total_bill").alias("gas"),
             pl.col("propane_total_bill").alias("propane"),
             pl.col("oil_total_bill").alias("oil"),
-            pl.col("energy_total_bill").alias("energy_total"),
+            (
+                pl.col("elec_fixed_charge")
+                + pl.col("elec_delivery_bill")
+                + pl.col("elec_supply_bill")
+                + pl.col("gas_total_bill")
+                + pl.col("oil_total_bill")
+                + pl.col("propane_total_bill")
+            ).alias("energy_total"),
             "heats_with_natgas",
             "in.hvac_cooling_partial_space_conditioning",
         )
@@ -1211,8 +1271,10 @@ _lx = _n + 0.6
 
 How do total energy bills change when homes switch to heat pumps under today's
 default flat rates? We compute the delta between each building's annual bill
-before (run 1+2, current HVAC) and after (run 3+4, heat pump upgrade). The
-`energy_total_bill` field includes electric, gas, oil, and propane costs.
+before (run 1+2, current HVAC) and after (run 3+4, heat pump upgrade). After
+ingest, `energy_total_bill` is rewritten as the sum of ``ACTIVE_BILL_COLS``
+(electric + gas + oil + propane), so bill-change deltas follow
+``INCLUDE_LMI_DISCOUNT`` symmetrically on both sides of the join.
 
 ```{python}
 #| label: compute-bill-deltas
@@ -1280,6 +1342,7 @@ def plot_quadrant_bar(
     rows: list[tuple[str, pl.DataFrame]],
     title: str = "How bills would change after switching to heat pumps:",
     title_parts: list[tuple[str, str]] | None = None,
+    footnote: str | None = None,
 ) -> ggplot | Figure:
     """Horizontal stacked bar(s) showing quadrant proportions.
 
@@ -1427,6 +1490,8 @@ def plot_quadrant_bar(
             x_pos = bb.transformed(fig.transFigure.inverted()).x1
             if i < len(title_parts) - 1:
                 x_pos += space_fig
+        if footnote:
+            add_matplotlib_footnote(fig, footnote)
         return fig
 
     return p
@@ -1446,6 +1511,7 @@ def plot_quadrant_bar_by_utility(
     fuel_filter: pl.Expr,
     title_parts: list[tuple[str, str]],
     scenario_labels: tuple[str, str] = ("Default rate", "HP seasonal rate"),
+    footnote: str | None = None,
 ) -> None:
     """Grouped quadrant bars for each utility in a single tall figure.
 
@@ -1571,6 +1637,8 @@ def plot_quadrant_bar_by_utility(
         if i < len(title_parts) - 1:
             x_pos += space_fig
 
+    if footnote:
+        add_matplotlib_footnote(fig, footnote)
     display_svg(fig)
 ```
 
@@ -1757,8 +1825,10 @@ _hist_binned = (
 
 ### LMI scenarios (natgas, statewide)
 
-We recompute the bill delta for natural gas households using the LMI-discounted bill columns. For non-LMI households
-these columns equal the undiscounted values, so only LMI households' deltas shift.
+We recompute the bill delta for natural gas households using the LMI bill columns
+for the enrollment rate set by ``LMI_CURRENT_ENROLLMENT_PCT`` (40 or 100). For
+non-LMI households these columns equal the undiscounted values, so only LMI
+households' deltas shift.
 
 ```{python}
 #| label: compute-lmi-bill-deltas-state
@@ -1800,50 +1870,42 @@ def _lmi_delta_state(
     )
 
 
-delta_state_lmi40 = _lmi_delta_state(
-    bills_current, bills_hp, LMI_40_BILL_COLS, LMI_40_BILL_COLS,
-)
-delta_state_lmi_full = _lmi_delta_state(
-    bills_current, bills_hp, LMI_40_BILL_COLS, LMI_100_BILL_COLS,
+delta_state_lmi_enrolled = _lmi_delta_state(
+    bills_current, bills_hp, LMI_ENROLLED_BILL_COLS, LMI_ENROLLED_BILL_COLS,
 )
 
-natgas_state_lmi40 = (
-    delta_state_lmi40
+natgas_state_lmi_enrolled = (
+    delta_state_lmi_enrolled
     .filter(pl.col("heats_with_natgas"))
     .select("delta", "weight")
 )
-_lmi40_def_total = natgas_state_lmi40["weight"].sum()
-_lmi40_def_save = natgas_state_lmi40.filter(pl.col("delta") < 0)["weight"].sum()
-_lmi40_def_lose_1k = natgas_state_lmi40.filter(pl.col("delta") > 1000)["weight"].sum()
+_lmi40_def_total = natgas_state_lmi_enrolled["weight"].sum()
+_lmi40_def_save = natgas_state_lmi_enrolled.filter(pl.col("delta") < 0)["weight"].sum()
+_lmi40_def_lose_1k = natgas_state_lmi_enrolled.filter(pl.col("delta") > 1000)["weight"].sum()
 report_vars["pct_natgas_save_default_lmi40"] = _lmi40_def_save / _lmi40_def_total
 report_vars["pct_natgas_lose_1k_default_lmi40"] = _lmi40_def_lose_1k / _lmi40_def_total
-
-natgas_state_lmi_full = (
-    delta_state_lmi_full
-    .filter(pl.col("heats_with_natgas"))
-    .select("delta", "weight")
-)
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-state-state-lmi-current
-#| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide). Assumes 40% of LMI households receive LMI discounts before and after switching to HP."
+#| fig-cap: "Bill impact of switching to heat pumps for natural gas-heated households (Statewide)."
 
 plot_quadrant_bar(
-    [("Natural gas", natgas_state_lmi40)],
+    [("Natural gas", natgas_state_lmi_enrolled)],
     title_parts=[
         ("How bills would change for ", "#000000"),
         ("natural gas", "#7A8A10"),
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
-        ("\n(with current LMI discounts)", "#000000"),
+        (f"\n(~{LMI_CURRENT_ENROLLMENT_PCT}% LMI discounts)", "#000000"),
     ],
+    footnote=LMI_ENROLLED_CAPTION,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-oil-propane-state
-#| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Bill impact of switching to heat pumps for oil/propane-heated households (Statewide)."
 
 plot_quadrant_bar(
     [("Oil / propane", oil_propane_state)],
@@ -1855,12 +1917,13 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-state
-#| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Bill impact of switching to heat pumps for electric resistance-heated households (Statewide)."
 
 plot_quadrant_bar(
     [("Electric resistance", elec_resistance_state)],
@@ -1870,6 +1933,7 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4366,7 +4430,7 @@ display_svg(fig_3bar)
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-switch-hprate-by-utility
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility. Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate, by utility."
 
 plot_quadrant_bar_by_utility(
     delta_state, delta_switch_state,
@@ -4378,6 +4442,7 @@ plot_quadrant_bar_by_utility(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4405,7 +4470,7 @@ if INCLUDE_TOU:
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-tou-state
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. fair vs. TOU + fair rate (Statewide)."
 
 if INCLUDE_TOU:
     _tou_quadrant_fig = plot_quadrant_bar(
@@ -4420,6 +4485,7 @@ if INCLUDE_TOU:
             (" heated homes after switching to ", "#000000"),
             ("heat pumps", "#c47600"),
         ],
+        footnote=LMI_CAPTION_SUFFIX,
     )
     _q_fair = quadrant_pcts(natgas_switch_state)
     _q_tou = quadrant_pcts(natgas_tou_state)
@@ -4510,27 +4576,28 @@ _tou_hist_fig
 
 ### LMI scenarios — default vs. fair rate (natgas, statewide)
 
-We recompute the two-bar comparison (default rate vs. seasonal rate) using LMI-discounted bill columns. The
-seasonal-rate "after" comes from `bills_hprate_hp` (`RUN_HPRATE_HP`) instead of `bills_hp` (runs 3+4).
+We recompute the two-bar comparison (default rate vs. seasonal rate) using the
+LMI bill columns for ``LMI_CURRENT_ENROLLMENT_PCT``. The seasonal-rate "after"
+comes from `bills_hprate_hp` (`RUN_HPRATE_HP`) instead of `bills_hp` (runs 3+4).
 
 ```{python}
 #| label: compute-lmi-switch-deltas-state
 
-delta_switch_state_lmi40 = _lmi_delta_state(
-    bills_current, bills_hprate_hp, LMI_40_BILL_COLS, LMI_40_BILL_COLS,
+delta_switch_state_lmi_enrolled = _lmi_delta_state(
+    bills_current, bills_hprate_hp, LMI_ENROLLED_BILL_COLS, LMI_ENROLLED_BILL_COLS,
 )
 delta_switch_state_lmi_full = _lmi_delta_state(
     bills_current, bills_hprate_hp, LMI_40_BILL_COLS, LMI_100_BILL_COLS,
 )
 
-natgas_switch_state_lmi40 = (
-    delta_switch_state_lmi40
+natgas_switch_state_lmi_enrolled = (
+    delta_switch_state_lmi_enrolled
     .filter(pl.col("heats_with_natgas"))
     .select("delta", "weight")
 )
-_lmi40_total = natgas_switch_state_lmi40["weight"].sum()
-_lmi40_save = natgas_switch_state_lmi40.filter(pl.col("delta") < 0)["weight"].sum()
-_lmi40_lose_1k = natgas_switch_state_lmi40.filter(pl.col("delta") > 1000)["weight"].sum()
+_lmi40_total = natgas_switch_state_lmi_enrolled["weight"].sum()
+_lmi40_save = natgas_switch_state_lmi_enrolled.filter(pl.col("delta") < 0)["weight"].sum()
+_lmi40_lose_1k = natgas_switch_state_lmi_enrolled.filter(pl.col("delta") > 1000)["weight"].sum()
 report_vars["pct_natgas_save_hprate_lmi40"] = _lmi40_save / _lmi40_total
 report_vars["pct_natgas_lose_1k_hprate_lmi40"] = _lmi40_lose_1k / _lmi40_total
 
@@ -4548,12 +4615,12 @@ report_vars["pct_natgas_save_1k_hprate_lmi_full"] = _lmif_save_1k / _lmif_total
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-switch-hprate-state-lmi-current
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide). Assumes 40% of LMI households receive LMI discounts before and after switching to HP."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default vs. seasonal rate (Statewide)."
 
 plot_quadrant_bar(
     [
-        ("Default rate", natgas_state_lmi40),
-        ("HP seasonal rate", natgas_switch_state_lmi40),
+        ("Default rate", natgas_state_lmi_enrolled),
+        ("HP seasonal rate", natgas_switch_state_lmi_enrolled),
     ],
     title_parts=[
         ("How bills would change for ", "#000000"),
@@ -4561,12 +4628,13 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_ENROLLED_CAPTION,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-oil-propane-switch-hprate-state
-#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate (Statewide)."
 
 plot_quadrant_bar(
     [
@@ -4581,12 +4649,13 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-oil-propane-switch-hprate-by-utility
-#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility. Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Change in total annual energy bills — oil/propane homes switching to HP: default vs. seasonal rate, by utility."
 
 plot_quadrant_bar_by_utility(
     delta_state, delta_switch_state,
@@ -4600,12 +4669,13 @@ plot_quadrant_bar_by_utility(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-switch-hprate-state
-#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide). Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate (Statewide)."
 
 plot_quadrant_bar(
     [
@@ -4618,12 +4688,13 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-switch-hprate-by-utility
-#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility. Undiscounted annual bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Change in total annual energy bills — electric resistance homes switching to HP: default vs. seasonal rate, by utility."
 
 plot_quadrant_bar_by_utility(
     delta_state, delta_switch_state,
@@ -4635,6 +4706,7 @@ plot_quadrant_bar_by_utility(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -4652,42 +4724,43 @@ The EH-rate master bills come from runs `RUN_EHRATE` (u0, all homes keep current
 HVAC; electric heaters on EH rate, others on recalibrated flat rate) and
 `RUN_EHRATE_HP` (u2, all homes on heat pumps, all on EH rate).
 
-### Gas → HP under the electric heating rate (LMI-40)
+### Gas → HP under the electric heating rate (LMI-enrolled bills)
 
 Mirrors the seasonal-rate gas switch comparison above: Bar 1 is the gas customer
 switching to HP under today's default rate, Bar 2 is the same customer switching
 to HP under the EH rate. The "before" state is identical in both bars (baseline
 HVAC on default rate), so differences come entirely from the "after" rate regime.
-We use LMI-40 bill columns to match the primary reference chart.
+We use the bill columns matching ``LMI_CURRENT_ENROLLMENT_PCT`` (40 or 100 in
+parquet) to align with the primary reference chart.
 
 ```{python}
-#| label: compute-deltas-natgas-switch-ehrate-lmi40
+#| label: compute-deltas-natgas-switch-ehrate-lmi-enrolled
 
-delta_switch_state_ehrate_lmi40 = _lmi_delta_state(
-    bills_current, bills_ehrate_hp, LMI_40_BILL_COLS, LMI_40_BILL_COLS,
+delta_switch_state_ehrate_lmi_enrolled = _lmi_delta_state(
+    bills_current, bills_ehrate_hp, LMI_ENROLLED_BILL_COLS, LMI_ENROLLED_BILL_COLS,
 )
-natgas_switch_ehrate_state_lmi40 = (
-    delta_switch_state_ehrate_lmi40
+natgas_switch_ehrate_state_lmi_enrolled = (
+    delta_switch_state_ehrate_lmi_enrolled
     .filter(pl.col("heats_with_natgas"))
     .select("delta", "weight")
 )
 
-_lmi40_eh_total = natgas_switch_ehrate_state_lmi40["weight"].sum()
-_lmi40_eh_save = natgas_switch_ehrate_state_lmi40.filter(pl.col("delta") < 0)["weight"].sum()
-_lmi40_eh_lose_1k = natgas_switch_ehrate_state_lmi40.filter(pl.col("delta") > 1000)["weight"].sum()
+_lmi40_eh_total = natgas_switch_ehrate_state_lmi_enrolled["weight"].sum()
+_lmi40_eh_save = natgas_switch_ehrate_state_lmi_enrolled.filter(pl.col("delta") < 0)["weight"].sum()
+_lmi40_eh_lose_1k = natgas_switch_ehrate_state_lmi_enrolled.filter(pl.col("delta") > 1000)["weight"].sum()
 report_vars["pct_natgas_save_ehrate_lmi40"] = _lmi40_eh_save / _lmi40_eh_total
 report_vars["pct_natgas_lose_1k_ehrate_lmi40"] = _lmi40_eh_lose_1k / _lmi40_eh_total
 ```
 
 ```{python}
 #| label: fig-quadrant-bar-natgas-switch-ehrate-state-lmi-current
-#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide). Assumes 40% of LMI households receive LMI discounts before and after switching to HP."
+#| fig-cap: "Change in total annual energy bills — natural gas homes switching to HP: default rate vs. electric heating rate (Statewide)."
 
 plot_quadrant_bar(
     [
-        ("Default rate", natgas_state_lmi40),
-        ("HP seasonal rate", natgas_switch_state_lmi40),
-        ("Electric heating rate", natgas_switch_ehrate_state_lmi40),
+        ("Default rate", natgas_state_lmi_enrolled),
+        ("HP seasonal rate", natgas_switch_state_lmi_enrolled),
+        ("Electric heating rate", natgas_switch_ehrate_state_lmi_enrolled),
     ],
     title_parts=[
         ("How bills would change for ", "#000000"),
@@ -4695,6 +4768,7 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_ENROLLED_CAPTION,
 )
 ```
 
@@ -4746,7 +4820,7 @@ report_vars["mean_monthly_er_stay_delta_ehrate"] = (
 
 ```{python}
 #| label: fig-hist-elec-resistance-stay-ehrate-state
-#| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide. Undiscounted bills (LMI discount enrollment not modeled)."
+#| fig-cap: "Distribution of annual bill savings for electric resistance homes staying on ER equipment under the electric heating rate vs. the default rate (Statewide). Bins are $50/yr wide."
 
 _annual_er_stay = (
     elec_resistance_stay_ehrate_state
@@ -4765,7 +4839,7 @@ _pct = _counts / _counts.sum() * 100
 
 _hist_df = pl.DataFrame({"bin_center": _centers, "pct": _pct})
 
-(
+_p_er_hist = (
     ggplot(_hist_df, aes(x="bin_center", y="pct"))
     + geom_col(fill="#4caf50", width=_bin_w * 0.95)
     + scale_x_continuous(labels=lambda xs: [f"${x:.0f}" for x in xs])
@@ -4780,6 +4854,9 @@ _hist_df = pl.DataFrame({"bin_center": _centers, "pct": _pct})
         plot_title=element_text(ha="left", margin={"b": 4, "units": "pt"}),
     )
 )
+_fig_er_hist = _p_er_hist.draw()
+add_matplotlib_footnote(_fig_er_hist, LMI_CAPTION_SUFFIX)
+display_svg(_fig_er_hist)
 ```
 
 ### Cost shift to fossil-heated (non-electric-heating) customers
@@ -4849,7 +4926,7 @@ fossil_hprate_state = (
 
 ```{python}
 #| label: fig-bill-change-fossil-ehrate-state
-#| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only. Undiscounted bills."
+#| fig-cap: "Monthly bill change — non-electric-heating homes (natural gas, fuel oil, propane, other) under the HP seasonal rate vs. the electric heating rate (Statewide). Equipment held constant at baseline; delta reflects the recalibrated flat rate only."
 
 REBAL_3_COLORS = {
     "increase < $5/mo": "#ef9a9a",
@@ -4964,7 +5041,9 @@ p = (
 )
 for _a in _annotations:
     p = p + _a
-p
+_fig_fossil_eh = p.draw()
+add_matplotlib_footnote(_fig_fossil_eh, LMI_CAPTION_SUFFIX)
+display_svg(_fig_fossil_eh)
 ```
 
 ### ER → HP savings under three rate regimes
@@ -5069,7 +5148,7 @@ report_vars["mean_er_switch_delta_ehrate"] = _weighted_mean(
 
 ```{python}
 #| label: fig-quadrant-bar-elec-resistance-switch-three-regimes-state
-#| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after. Undiscounted annual bills."
+#| fig-cap: "Annual bill change for electric resistance homes switching to HP under three rate regimes (Statewide). Bar 1: default rate before and after. Bar 2: default rate before, HP seasonal rate after. Bar 3: EH rate before and after."
 
 plot_quadrant_bar(
     [
@@ -5083,6 +5162,7 @@ plot_quadrant_bar(
         (" heated homes after switching to ", "#000000"),
         ("heat pumps", "#c47600"),
     ],
+    footnote=LMI_CAPTION_SUFFIX,
 )
 ```
 
@@ -5119,7 +5199,7 @@ delta_rebal_state = annual_before_rebal_state.join(annual_after_rebal_state, on=
 
 ```{python}
 #| label: fig-bill-change-non-hp-rebal-state
-#| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide)"
+#| fig-cap: "Average monthly bill change — all non-HP homes after cross-subsidy removal (Statewide)."
 
 REBAL_3_COLORS = {
     "bill decrease": "#81c784",
@@ -5203,7 +5283,9 @@ p = (
 )
 for _a in _annotations:
     p = p + _a
-p
+_fig_rebal = p.draw()
+add_matplotlib_footnote(_fig_rebal, LMI_CAPTION_SUFFIX)
+display_svg(_fig_rebal)
 ```
 
 ```{python}
@@ -5266,8 +5348,8 @@ def burden_shares(
     """Return (weighted_pct_below, weighted_pct_above) the burden threshold.
 
     bill_cols controls which columns are summed to form the total energy bill.
-    Default uses the undiscounted columns; pass LMI_40_BILL_COLS or
-    LMI_100_BILL_COLS to use LMI-discounted bills.
+    Default uses the undiscounted columns; pass ``LMI_ENROLLED_BILL_COLS``,
+    ``LMI_40_BILL_COLS``, or ``LMI_100_BILL_COLS`` for LMI-tiered bills.
     """
     annual = (
         bills_lf
@@ -5380,30 +5462,32 @@ def plot_burden_bar(
     )
 ```
 
-### With current LMI discount enrollment (~40%)
+### With modeled LMI discount enrollment
 
-An estimated 40% of LMI households currently receive LMI discounts on their utility bills. We recompute energy burdens
-using the `_lmi_40` bill columns, which apply the discount to those households who are currently enrolled.
+Energy burdens in the first three scenarios use the bill columns for
+``LMI_CURRENT_ENROLLMENT_PCT`` (40 or 100). The fourth scenario contrasts universal
+100% enrollment (``_lmi_100`` columns) against that modeled tier.
 
 ```{python}
 #| label: burden-compute-lmi-current
 
 below_current_lmi40, above_current_lmi40 = burden_shares(
-    bills_current, cohort_bldg_ids, income_df, bill_cols=LMI_40_BILL_COLS,
+    bills_current, cohort_bldg_ids, income_df, bill_cols=LMI_ENROLLED_BILL_COLS,
 )
 below_hp_default_lmi40, above_hp_default_lmi40 = burden_shares(
-    bills_hp, cohort_bldg_ids, income_df, bill_cols=LMI_40_BILL_COLS,
+    bills_hp, cohort_bldg_ids, income_df, bill_cols=LMI_ENROLLED_BILL_COLS,
 )
 below_hp_seasonal_lmi40, above_hp_seasonal_lmi40 = burden_shares(
-    bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_40_BILL_COLS,
+    bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_ENROLLED_BILL_COLS,
 )
 below_hp_seasonal_lmi100, above_hp_seasonal_lmi100 = burden_shares(
     bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_100_BILL_COLS,
 )
 
-print(f"Current HVAC (40% enrolled):         {above_current_lmi40:.1f}% above 6%")
-print(f"HP + default rates (40% enrolled):   {above_hp_default_lmi40:.1f}% above 6%")
-print(f"HP + seasonal rates (40% enrolled):  {above_hp_seasonal_lmi40:.1f}% above 6%")
+_pct = LMI_CURRENT_ENROLLMENT_PCT
+print(f"Current HVAC ({_pct}% enrolled):         {above_current_lmi40:.1f}% above 6%")
+print(f"HP + default rates ({_pct}% enrolled):   {above_hp_default_lmi40:.1f}% above 6%")
+print(f"HP + seasonal rates ({_pct}% enrolled):  {above_hp_seasonal_lmi40:.1f}% above 6%")
 print(f"HP + seasonal rates (100% enrolled): {above_hp_seasonal_lmi100:.1f}% above 6%")
 
 report_vars["pct_burdened_hp_seasonal_lmi100"] = above_hp_seasonal_lmi100 / 100
@@ -5413,10 +5497,16 @@ report_vars["pct_burdened_hp_seasonal_lmi100"] = above_hp_seasonal_lmi100 / 100
 #| label: fig-burden-bar-lmi-current
 #| fig-cap: "Share of low-income gas-heated households above the 6% energy burden threshold"
 
-plot_burden_bar(
+_p_burden_lmi = plot_burden_bar(
     [below_current_lmi40, below_hp_default_lmi40, below_hp_seasonal_lmi40, below_hp_seasonal_lmi100],
     [above_current_lmi40, above_hp_default_lmi40, above_hp_seasonal_lmi40, above_hp_seasonal_lmi100],
 )
+_fig_burden_lmi = _p_burden_lmi.draw()
+add_matplotlib_footnote(
+    _fig_burden_lmi,
+    LMI_ENROLLED_CAPTION + " Rightmost bar: universal 100% enrollment (_lmi_100 columns) on the HP seasonal rate.",
+)
+display_svg(_fig_burden_lmi)
 ```
 
 #### By utility
@@ -5433,9 +5523,9 @@ for code in UTIL_ORDER_CODES:
         continue
     util_income = income_df.filter(pl.col(BLDG_ID).is_in(util_bldg_ids))
     burden_by_utility[code] = {
-        "current": burden_shares(bills_current, util_bldg_ids, util_income, bill_cols=LMI_40_BILL_COLS),
-        "hp_default": burden_shares(bills_hp, util_bldg_ids, util_income, bill_cols=LMI_40_BILL_COLS),
-        "hp_seasonal": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_40_BILL_COLS),
+        "current": burden_shares(bills_current, util_bldg_ids, util_income, bill_cols=LMI_ENROLLED_BILL_COLS),
+        "hp_default": burden_shares(bills_hp, util_bldg_ids, util_income, bill_cols=LMI_ENROLLED_BILL_COLS),
+        "hp_seasonal": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_ENROLLED_BILL_COLS),
         "hp_seasonal_lmi100": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_100_BILL_COLS),
     }
 
@@ -5567,11 +5657,10 @@ def plot_burden_bar_by_utility(
 
     display_svg(fig)
 ```
-pe
 
 ```{python}
 #| label: fig-burden-bar-lmi-current-by-utility
-#| fig-cap: "Share of low-income gas-heated households above the 6% energy burden threshold by utility, with current LMI discount enrollment (~40%)"
+#| fig-cap: "Share of low-income gas-heated households above the 6% energy burden threshold by utility, with modeled LMI discount enrollment (see constants cell)."
 
 plot_burden_bar_by_utility(
     burden_by_utility, UTIL_NAMES,

--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -1586,10 +1586,9 @@ def plot_quadrant_bar_by_utility(
             ax.barh(bp, width, left=left, height=_QBU_BAR_HEIGHT,
                     color=QUADRANT_COLORS[q], edgecolor="none", align="edge")
             if width >= 3:
-                ax.text(left + width / 2, bp + _QBU_BAR_HEIGHT / 2, f"{width:.1f}%",
                         ha="center", va="center", color="white",
                         fontsize=10, fontweight="bold", fontfamily="IBM Plex Sans")
-            left += width
+                        fontsize=10, fontweight="bold", fontfamily="IBM Plex Sans")
 
     for bp, label in zip(bar_positions, bar_scenario_labels):
         ax.text(101, bp + _QBU_BAR_HEIGHT / 2, label,
@@ -1607,7 +1606,7 @@ def plot_quadrant_bar_by_utility(
             mid = cum + first_pct[q] / 2
             cum += first_pct[q]
             if first_pct[q] < 2:
-                continue
+            if first_pct[q] < 2:
             ax.text(mid, label_y, QUADRANT_LABELS[q],
                     ha="center", va="bottom", fontsize=8,
                     fontweight="bold", color=QUADRANT_COLORS[q],
@@ -5477,32 +5476,30 @@ def plot_burden_bar(
     )
 ```
 
-### With modeled LMI discount enrollment
+### With current LMI discount enrollment (~40%)
 
-Energy burdens in the first three scenarios use the bill columns for
-``LMI_CURRENT_ENROLLMENT_PCT`` (40 or 100). The fourth scenario contrasts universal
-100% enrollment (``_lmi_100`` columns) against that modeled tier.
+An estimated 40% of LMI households currently receive LMI discounts on their utility bills. We recompute energy burdens
+using the `_lmi_40` bill columns, which apply the discount to those households who are currently enrolled.
 
 ```{python}
 #| label: burden-compute-lmi-current
 
 below_current_lmi40, above_current_lmi40 = burden_shares(
-    bills_current, cohort_bldg_ids, income_df, bill_cols=ACTIVE_BILL_COLS,
+    bills_current, cohort_bldg_ids, income_df, bill_cols=LMI_40_BILL_COLS,
 )
 below_hp_default_lmi40, above_hp_default_lmi40 = burden_shares(
-    bills_hp, cohort_bldg_ids, income_df, bill_cols=ACTIVE_BILL_COLS,
+    bills_hp, cohort_bldg_ids, income_df, bill_cols=LMI_40_BILL_COLS,
 )
 below_hp_seasonal_lmi40, above_hp_seasonal_lmi40 = burden_shares(
-    bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=ACTIVE_BILL_COLS,
+    bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_40_BILL_COLS,
 )
 below_hp_seasonal_lmi100, above_hp_seasonal_lmi100 = burden_shares(
     bills_hprate_hp, cohort_bldg_ids, income_df, bill_cols=LMI_100_BILL_COLS,
 )
 
-_pct = LMI_CURRENT_ENROLLMENT_PCT
-print(f"Current HVAC ({_pct}% enrolled):         {above_current_lmi40:.1f}% above 6%")
-print(f"HP + default rates ({_pct}% enrolled):   {above_hp_default_lmi40:.1f}% above 6%")
-print(f"HP + seasonal rates ({_pct}% enrolled):  {above_hp_seasonal_lmi40:.1f}% above 6%")
+print(f"Current HVAC (40% enrolled):         {above_current_lmi40:.1f}% above 6%")
+print(f"HP + default rates (40% enrolled):   {above_hp_default_lmi40:.1f}% above 6%")
+print(f"HP + seasonal rates (40% enrolled):  {above_hp_seasonal_lmi40:.1f}% above 6%")
 print(f"HP + seasonal rates (100% enrolled): {above_hp_seasonal_lmi100:.1f}% above 6%")
 
 report_vars["pct_burdened_hp_seasonal_lmi100"] = above_hp_seasonal_lmi100 / 100
@@ -5512,17 +5509,10 @@ report_vars["pct_burdened_hp_seasonal_lmi100"] = above_hp_seasonal_lmi100 / 100
 #| label: fig-burden-bar-lmi-current
 #| fig-cap: "Share of low-income gas-heated households above the 6% energy burden threshold"
 
-_p_burden_lmi = plot_burden_bar(
+plot_burden_bar(
     [below_current_lmi40, below_hp_default_lmi40, below_hp_seasonal_lmi40, below_hp_seasonal_lmi100],
     [above_current_lmi40, above_hp_default_lmi40, above_hp_seasonal_lmi40, above_hp_seasonal_lmi100],
 )
-_fig_burden_lmi = _p_burden_lmi.draw()
-add_matplotlib_footnote(
-    _fig_burden_lmi,
-    LMI_CAPTION_SUFFIX
-    + " Rightmost bar: universal 100% enrollment (_lmi_100 columns) on the HP seasonal rate.",
-)
-display_svg(_fig_burden_lmi)
 ```
 
 #### By utility
@@ -5539,9 +5529,9 @@ for code in UTIL_ORDER_CODES:
         continue
     util_income = income_df.filter(pl.col(BLDG_ID).is_in(util_bldg_ids))
     burden_by_utility[code] = {
-        "current": burden_shares(bills_current, util_bldg_ids, util_income, bill_cols=ACTIVE_BILL_COLS),
-        "hp_default": burden_shares(bills_hp, util_bldg_ids, util_income, bill_cols=ACTIVE_BILL_COLS),
-        "hp_seasonal": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=ACTIVE_BILL_COLS),
+        "current": burden_shares(bills_current, util_bldg_ids, util_income, bill_cols=LMI_40_BILL_COLS),
+        "hp_default": burden_shares(bills_hp, util_bldg_ids, util_income, bill_cols=LMI_40_BILL_COLS),
+        "hp_seasonal": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_40_BILL_COLS),
         "hp_seasonal_lmi100": burden_shares(bills_hprate_hp, util_bldg_ids, util_income, bill_cols=LMI_100_BILL_COLS),
     }
 
@@ -5562,20 +5552,12 @@ _BURDEN_LABEL_ABOVE = "ENERGY BURDEN ABOVE 6%"
 _BURDEN_LABEL_BELOW = "ENERGY BURDEN BELOW 6%"
 
 _BURDEN_UTIL_SCENARIO_KEYS = ["current", "hp_default", "hp_seasonal", "hp_seasonal_lmi100"]
-if INCLUDE_LMI_DISCOUNT:
-    _BURDEN_UTIL_SCENARIO_LABELS = [
-        f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-        f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-        f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
-    ]
-else:
-    _BURDEN_UTIL_SCENARIO_LABELS = [
-        "Current HVAC\nDefault Rates\n(undiscounted bills)",
-        "Heat Pump\nDefault Rates\n(undiscounted bills)",
-        "Heat Pump\nHP Seasonal Rates\n(undiscounted bills)",
-        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
-    ]
+_BURDEN_UTIL_SCENARIO_LABELS = [
+    f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+    f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+    f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+    "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
+]
 
 
 def plot_burden_bar_by_utility(
@@ -5682,9 +5664,10 @@ def plot_burden_bar_by_utility(
     display_svg(fig)
 ```
 
+
 ```{python}
 #| label: fig-burden-bar-lmi-current-by-utility
-#| fig-cap: "Share of low-income gas-heated households above the 6% energy burden threshold by utility, with modeled LMI discount enrollment (see constants cell)."
+#| fig-cap: "Share of low-income gas-heated households above the 6% energy burden threshold by utility, with current LMI discount enrollment (~40%)"
 
 plot_burden_bar_by_utility(
     burden_by_utility, UTIL_NAMES,

--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -5394,20 +5394,12 @@ print(f"HP + seasonal rates: {above_hp_seasonal:.1f}% above 6% | {below_hp_seaso
 ```{python}
 #| label: burden-bar-helper
 
-if INCLUDE_LMI_DISCOUNT:
-    BURDEN_SCENARIO_LABELS = [
-        f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-        f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-        f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
-        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
-    ]
-else:
-    BURDEN_SCENARIO_LABELS = [
-        "Current HVAC\nDefault Rates\n(undiscounted bills)",
-        "Heat Pump\nDefault Rates\n(undiscounted bills)",
-        "Heat Pump\nHP Seasonal Rates\n(undiscounted bills)",
-        "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
-    ]
+BURDEN_SCENARIO_LABELS = [
+    f"Current HVAC\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+    f"Heat Pump\nDefault Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+    f"Heat Pump\nHP Seasonal Rates\n~{LMI_CURRENT_ENROLLMENT_PCT}% LMI Discounts",
+    "Heat Pump\nHP Seasonal Rates\n100% LMI Discounts",
+]
 BURDEN_SEGMENT_ORDER = ["Above 6%", "Below 6%"]
 BURDEN_COLORS = {
     "Above 6%": SB_COLORS["carrot"],

--- a/reports/ri_hp_rates/index.qmd
+++ b/reports/ri_hp_rates/index.qmd
@@ -907,7 +907,7 @@ All homes in the Rhode Island ResStock sample are assigned to Rhode Island Energ
 
 For each building, we apply the relevant tariffs to the building's hourly electricity load profile and annual fossil fuel consumption to calculate total annual energy bills.[^link_cairo]  We apply 12 months of electric fixed charges, and 12 months of gas fixed charges if they are a gas-heated building. Then, we apply the volumetric electricity, gas, heating oil, and propane rates to the amount of these fuels they consumed in each hour (few buildings consume all of them at once). The sum of these is the building's total annual energy bill.
 
-We do this for all buildings under upgrade scenario 0, where their load profiles reflect their current HVAC system, and again for all buildings under upgrade scenario 2, where their load profiles reflect the removal of a furnace, boiler, or electric resistance heater for either a centralized heat pump, or mini-splits. 
+We do this for all buildings under upgrade scenario 0, where their load profiles reflect their current HVAC system, and again for all buildings under upgrade scenario 2, where their load profiles reflect the removal of a furnace, boiler, or electric resistance heater for either a centralized heat pump, or mini-splits.
 
 The **bill change from switching to a heat pump** is the difference between a building's total annual energy bill (electricity plus gas, oil, and propane) under its current heating equipment and after a heat pump retrofit, both on today's default rates. A negative change means the household would save; a positive change means bills would rise.[^link_bill-changes]
 
@@ -966,7 +966,7 @@ The {{< glossary "marginal cost" >}} (or {{< glossary "economic burden" >}}) cap
 
 ---
 
-#### Why there is a residual 
+#### Why there is a residual
 
 ::: {.column-margin}
 {{< glossary-def residual >}}
@@ -976,7 +976,7 @@ The {{< glossary "marginal cost" >}} (or {{< glossary "economic burden" >}}) cap
 {{< glossary-def "revenue requirement" >}}
 :::
 
-When a utility builds a new substation, transformer, or power line, the cost of that investment gets spread over its useful life and added to the revenue requirement. Marginal cost pricing captures only the _new_ investment that an additional kilowatt of demand would trigger — specifically, the first year's depreciation on the infrastructure called into existence by that load. 
+When a utility builds a new substation, transformer, or power line, the cost of that investment gets spread over its useful life and added to the revenue requirement. Marginal cost pricing captures only the _new_ investment that an additional kilowatt of demand would trigger — specifically, the first year's depreciation on the infrastructure called into existence by that load.
 
 We call this **marginal capacity** to distinguish it from the short-run energy and ancillary costs already defined above. In practice, we measure this long-run marginal capacity cost (LRMC) using the **First-Year Levelized Investment Cost (FLIC)** approach: the near-term projects in the utility's capital plan serve as a proxy for what it costs to expand the system at the margin. Interpreted this way, the total marginal cost signal roughly represents the _newest tranche_ of capital on the revenue requirement — the costs that marginal load is currently triggering. (FLIC is not the only way to estimate LRMC; replacement cost and avoided cost methods are alternatives, but FLIC is grounded in actual planned investment.)
 
@@ -998,7 +998,7 @@ Our hourly marginal cost signal has five components, each derived from publicly 
 
 #### How marginal costs are allocated throughout the year
 
-In order to calculate the marginal cost for each customer, we need to know the total system marginal cost for each hour of the year. Each component produces a separate 8,760-hour signal. The signals differ in which hours carry non-zero costs. 
+In order to calculate the marginal cost for each customer, we need to know the total system marginal cost for each hour of the year. Each component produces a separate 8,760-hour signal. The signals differ in which hours carry non-zero costs.
 
 The five components combine into two cost categories **supply** and **delivery** which are modeled as separate CAIRO runs:
 
@@ -1024,7 +1024,7 @@ Customers who consume more electricity during peak hours — the hours when ener
 
 #### Marginal cost components
 
-Here we describe the methods used to generate the five components that make up marginal cost. 
+Here we describe the methods used to generate the five components that make up marginal cost.
 
 The capacity and transmission components use **exceedance weighting** to concentrate costs in peak hours. Throughout, we use the top $N = 100$ hours. Both exceedance weighting and the probability-of-peak method (used below for distribution) serve as proxies for the probability that a given hour is a capacity-binding peak, differing only in how sharply they concentrate costs.
 
@@ -1137,7 +1137,7 @@ Because the residual represents sunk costs that are not attributable to any cust
 
 - **Volumetric markup** — add a uniform $/kWh surcharge; each customer's share is proportional to their consumption. This is the dominant practice in U.S. rates. It is simple and feels equitable, but it distorts consumption decisions because customers face a price above marginal cost.
 - **Flat fixed charge** — divide the residual equally across all customers ($/customer/month). This is the most economically efficient option — it creates no incentive to change consumption — but can be regressive, since the same dollar charge weighs more heavily on low-usage households.
-- **Proportional to marginal cost causation (EPMC)** — each customer's share is proportional to their share of total system marginal costs. 
+- **Proportional to marginal cost causation (EPMC)** — each customer's share is proportional to their share of total system marginal costs.
 
 We use equi-proportional marginal cost ({{< glossary EPMC >}}) allocation: each customer's residual share is proportional to their share of total system marginal costs. If a subclass causes 3% of total marginal costs, it bears 3% of the residual. This is equivalent to scaling all marginal-cost-based rates by a uniform factor
 
@@ -1227,7 +1227,7 @@ Gas service remains on the flat LIDR unchanged from the current program.
 
 [^lidr-proposed]: DeSousa et al. direct testimony describing the proposed LIDR+ program [@rie_Docket2545GEApplication_2025b]; tier discounts from Table 7 of Blazunas testimony in the same docket [@rie_Docket2545GEApplication_2025a].
 
-**Our definition of "LMI household."** Throughout the {{< glossary "energy burden" >}} analysis, we define a low-and-moderate-income (LMI) household as any household at or below 250% FPL (the outer eligibility limit of LIDR+). This is a broader definition than the current LIDR program, which in practice reaches households up to roughly 185% FPL (the SNAP/LIHEAP income ceiling). We use the 250% FPL boundary because it reflects the full population that a reformed LMI program could serve, and to show what full LIDR+ uptake would mean for the entire eligible population. 
+**Our definition of "LMI household."** Throughout the {{< glossary "energy burden" >}} analysis, we define a low-and-moderate-income (LMI) household as any household at or below 250% FPL (the outer eligibility limit of LIDR+). This is a broader definition than the current LIDR program, which in practice reaches households up to roughly 185% FPL (the SNAP/LIHEAP income ceiling). We use the 250% FPL boundary because it reflects the full population that a reformed LMI program could serve, and to show what full LIDR+ uptake would mean for the entire eligible population.
 
 **Participation.** As of July 2024, approximately 36,320 households were enrolled in the A-60 electric discount rate. We estimated that to be roughly 32% of estimated eligible households.[^lidr-participation] We use this estimated 32% figure as our baseline participation scenario for both electric and gas discounts. Under the partial participation scenario, we sample 32% of eligible households uniformly. All households participating in the gas discount program were also assigned the electric discount program. We also model a 100% enrollment scenario to reflect bills under automatic enrollment.
 


### PR DESCRIPTION
## Summary

This PR adds an `INCLUUDE_LMI_DISCOUNT` toggle that can be turned `True` or `False` and the document will automatically grab the appropriate LMI discount columns and update the footnotes.

Closes #138 