### PR TITLE
[infra] Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1316,3 +1316,45 @@ When a task involves creating, updating, or referencing issues, use the Linear M
 | `just publish`    | Report dir | Copy to root `docs/`, inline SVGs, prune intermediates |
 | `just diff`       | Report dir | Diff current render against baseline                   |
 | `just clean`      | Report dir | Remove report caches                                   |
+
+## Cursor Cloud specific instructions
+
+### Environment setup
+
+The Cloud Agent VM is Ubuntu 24.04 (not the devcontainer). The update script installs system deps, uv, just, Quarto, yamlfmt, prek, R pak, Switchbox fonts, and then runs `uv sync` and `install-r-deps.sh`. After the update script runs, the dev environment is ready.
+
+### Private dependency: `cairo`
+
+The `cairo` Python package (from `NatLabRockies/CAIRO`, a private GitHub repo) is not accessible in Cloud Agent VMs. Use `uv sync --group dev --no-install-package cairo --no-install-package website-diff` to install Python deps. The venv at `/workspace/.venv` will work for everything except code that imports `cairo` or `website-diff` directly.
+
+### Running commands without `uv run`
+
+Because the private `cairo` dependency causes `uv run` to fail, run tools directly from the venv:
+
+- Lint: `ruff check .` and `ruff format --check .`
+- Typecheck: `ty check`
+- Test: `python -m pytest --doctest-modules tests/`
+- Quarto: `quarto render` (set `QUARTO_PYTHON=/workspace/.venv/bin/python`)
+
+The `just check` and `just test` commands use `uv run` internally and will fail due to the missing `cairo` dependency. Run the underlying tools directly instead.
+
+### PATH and environment variables
+
+These are set in `~/.bashrc`:
+
+```
+export PATH="$HOME/.local/bin:/workspace/.venv/bin:$PATH"
+export QUARTO_PYTHON=/workspace/.venv/bin/python
+```
+
+### Rendering reports
+
+Full report rendering (`just render`) requires AWS S3 credentials (the analysis notebooks fetch data from `s3://data.sb/`). Without AWS access, you can:
+
+- Render standalone `.qmd` files (not in manuscript mode): `quarto render file.qmd --to html`
+- Render `index.qmd` with `--no-execute` if the freeze cache already exists
+- Test the rendering pipeline with standalone test documents
+
+### R ggplot2 theme
+
+When rendering R documents outside of a report directory, `source("lib/ggplot/switchbox_theme.R")` calculates the project root from `getwd()`. Make sure the working directory is `/workspace` or a subdirectory of it, or the font path resolution will fail.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to AGENTS.md documenting:

- The private `cairo` dependency workaround (`--no-install-package cairo`)
- How to run lint/test/typecheck directly instead of via `uv run`
- PATH and environment variable setup
- Report rendering requirements (AWS S3 access for full renders)
- R ggplot2 theme font path resolution gotcha

These instructions help future Cloud Agents set up and operate in the dev environment without re-discovering these caveats.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6558071-d01a-4f6a-b18a-429f0ac16574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6558071-d01a-4f6a-b18a-429f0ac16574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

