### PR TITLE
[ny_hp_rates] Add fair default feasibility line analysis

### DIFF
--- a/reports/ny_hp_rates/_quarto.yml
+++ b/reports/ny_hp_rates/_quarto.yml
@@ -17,6 +17,7 @@ project:
     - notebooks/gold_book_peaks.qmd
     - notebooks/cost_of_service_by_subclass.qmd
     - notebooks/investigate_household_savings.qmd
+    - notebooks/fair_default_feasible_line.qmd
     - index.qmd
 manuscript:
   article: index.qmd

--- a/reports/ny_hp_rates/index.qmd
+++ b/reports/ny_hp_rates/index.qmd
@@ -3195,6 +3195,86 @@ For our distribution marginal cost input, we use the **Sub-TX + Distribution** i
 Sub-transmission lines and stations (69–115kV) deliver power to the distribution substations that serve customers —
 their costs are local delivery costs, not NYISO bulk system costs, and load growth drives investment at both levels.
 
+---
+
+## How we derived the feasible fair-default seasonal rates {#sec-methods-fair-default-feasible}
+
+The fair-default rate design (@sec-seasonal-rate) replaces the flat default delivery rate with a **monthly fixed charge** $F$ plus **two seasonal volumetric rates** — a winter rate $r_w$ and a summer rate $r_s$ — that apply to every residential customer, HP and non-HP alike. The rate has to do two things at once: collect the same total delivery revenue the utility collects today, _and_ leave HP customers paying their fair share. Those two requirements are the constraints below. They pin down a one-parameter family of solutions: for every choice of $F$, there is exactly one $(r_w, r_s)$ pair that satisfies both. The feasible-line plots trace that family.
+
+### The two constraints
+
+The inputs to the calculation are the per-group totals already produced by the BAT run (see @sec-methods-bat) and the monthly ResStock loads:
+
+- $N_{\text{class}}$, $N_{\text{HP}}$ — weighted customer counts for the full residential class and the HP subclass.
+- $B_{\text{class}}$, $B_{\text{HP}}$ — current annual delivery bills for each group under today's default rate.
+- $Q^{w}_{\text{class}}$, $Q^{s}_{\text{class}}$, $Q^{w}_{\text{HP}}$, $Q^{s}_{\text{HP}}$ — total winter and summer kWh for each group, summed from `load_curve_monthly`.
+- $\Delta_{\text{HP}}$ — the HP subclass cross-subsidy from the BAT (per-customer × $N_{\text{HP}}$).
+
+**C1 — class revenue requirement.** Total delivery revenue collected from the residential class under the new rate equals the revenue collected today (this is the {{< glossary "revenue requirement" >}} the utility has to recover):
+
+$$12 \cdot F \cdot N_{\text{class}} \;+\; r_w \cdot Q^{w}_{\text{class}} \;+\; r_s \cdot Q^{s}_{\text{class}} \;=\; B_{\text{class}}$$
+
+**C2 — HP subclass fair revenue.** Total delivery revenue collected from the HP subclass equals their **fair bill** — what they would pay if their cross-subsidy were eliminated. The fair bill is the current bill minus the cross-subsidy:
+
+$$12 \cdot F \cdot N_{\text{HP}} \;+\; r_w \cdot Q^{w}_{\text{HP}} \;+\; r_s \cdot Q^{s}_{\text{HP}} \;=\; B_{\text{HP}} - \Delta_{\text{HP}}$$
+
+By construction, if C2 holds, the post-rate HP cross-subsidy is zero. C1 ensures the utility stays whole.
+
+### Solving for the seasonal rates at each fixed charge
+
+C1 and C2 are two linear equations in three unknowns $(F, r_w, r_s)$. Treat $F$ as the policy lever and the system becomes 2-by-2 in $(r_w, r_s)$. Subtracting fixed-charge revenue from each side moves the system into the volumetric variables, and solving by elimination gives a closed-form solution that is **affine in $F$**:[^script-fair-default-feasible]
+
+$$r_w(F) = a_w + b_w \cdot F, \qquad r_s(F) = a_s + b_s \cdot F$$
+
+The intercepts $a_w, a_s$ and slopes $b_w, b_s$ are pinned entirely by the eight inputs above. Each utility has its own coefficients because each utility has its own customer counts, bills, and seasonal kWh. The two seasonal lines for each utility — $r_w(F)$ in winter and $r_s(F)$ in summer — are what the feasible-line plots show (@fig-feasible-lines-delivery).
+
+[^script-fair-default-feasible]: Closed-form derivation and feasibility computation in [`utils/mid/compute_fair_default_inputs.py`](https://github.com/switchbox-data/rate-design-platform/blob/1a57bfc481e915fdb8a615c49bcea0001861b364/utils/mid/compute_fair_default_inputs.py) (`fixed_charge_feasibility` and `_seasonal_rates_at_fixed_charge`).
+
+:::{.column-page-inset-right}
+{{< embed notebooks/fair_default_feasible_line.qmd#fig-feasible-lines-delivery >}}
+:::
+
+### What the feasibility range means
+
+A solution to C1 and C2 exists for any $F$, but a _usable_ rate also requires both volumetric rates to be non-negative. Each constraint $r_w(F) \geq 0$ and $r_s(F) \geq 0$ is linear in $F$, so each carves out a half-line; their intersection is the **feasible fixed-charge range** $[F_{\min}, F_{\max}]$ — the green band in the plots. Inside this band, the utility is whole, the HP cross-subsidy is zero, and both rates are non-negative. Outside it, one rate would have to flip negative — winter at low $F$, summer at high $F$.
+
+The lower bound $F_{\min}$ — the smallest fixed charge that makes the rate feasible — is the practically relevant one. It is what we call the **minimum feasible fixed charge** for that utility (@fig-feasible-fixed-charge-ranges-delivery).
+
+:::{.column-page-inset-right}
+{{< embed notebooks/fair_default_feasible_line.qmd#fig-feasible-fixed-charge-ranges-delivery >}}
+:::
+
+### Why the minimum feasible fixed charge has to be so high
+
+HP customers consume disproportionately in winter, so eliminating their cross-subsidy pushes the winter rate down and the summer rate up. The lower we hold $F$, the more of the cross-subsidy correction has to come through the volumetric rates alone — and at some point the winter rate would have to go negative. Raising $F$ shifts revenue collection into the fixed channel, which falls equally on every customer regardless of when they consume. That widens the room for a non-negative winter rate. The minimum feasible $F$ is just the breakeven point where the winter rate is exactly zero — any lower and you would be paying customers to use electricity in winter.[^min-feasible-floor]
+
+[^min-feasible-floor]: For most NY utilities, $F_{\min}$ is several times the current fixed charge — often `$30`–`$60` per month, against today's `$15`–`$25`. This is why the fair-default rate design pairs a sharply seasonal volumetric rate with a substantially higher fixed charge.
+
+### Loosening C2: the revenue-sufficient sweep
+
+The feasible line above keeps both constraints active and asks: _what rates eliminate the cross-subsidy?_ If we instead drop C2 and keep only C1, we get a much larger family of rates — every $(F, r_w, r_s)$ that simply keeps the utility whole. This is the **revenue-sufficient sweep**.
+
+With only C1, fix any $F$ and any $r_w$, and the summer rate is uniquely pinned:
+
+$$r_s(r_w, F) \;=\; \frac{B_{\text{class}} - 12 \cdot F \cdot N_{\text{class}} - r_w \cdot Q^{w}_{\text{class}}}{Q^{s}_{\text{class}}}$$
+
+When $r_w = r_s$, this reduces to the **flat rate** at fixed charge $F$ — the rate the class would pay if there were no seasonal differentiation. Sweeping $r_w$ down from the flat rate, $r_s$ rises monotonically. Because C2 is no longer enforced, the HP subclass generally still cross-subsidizes — but by how much?
+
+We measure that residual directly. At each $(F, r_w)$ pair, plug the C1-implied $r_s$ back into the HP bill formula and subtract the HP fair bill:
+
+$$\Delta_{\text{HP}}^{\text{post}}(F, r_w) \;=\; \big[ 12 F N_{\text{HP}} + r_w Q^{w}_{\text{HP}} + r_s(r_w, F) \cdot Q^{s}_{\text{HP}} \big] - \big( B_{\text{HP}} - \Delta_{\text{HP}} \big)$$
+
+Positive values mean HP customers are still overpaying; zero means we have landed on the feasible line. We sweep this for four representative fixed charges — the current charge, the minimum feasible charge, and two levels in between — and plot both the rate pairs (@fig-rev-sufficient-rates) and the residual HP cross-subsidy per customer (@fig-rev-sufficient-cross-subsidy).
+
+:::{.column-page-inset-right}
+{{< embed notebooks/fair_default_feasible_line.qmd#fig-rev-sufficient-rates >}}
+:::
+
+:::{.column-page-inset-right}
+{{< embed notebooks/fair_default_feasible_line.qmd#fig-rev-sufficient-cross-subsidy >}}
+:::
+
+The takeaway: at the current fixed charge, no choice of seasonal rates eliminates the cross-subsidy — at most we can chip away at it. The cross-subsidy only goes to zero when $F$ reaches the minimum feasible charge _and_ the seasonal rates land exactly on the feasible line. That is the upper-left corner of the green band in the feasible-line plots.
 
 # References
 

--- a/reports/ny_hp_rates/index.qmd
+++ b/reports/ny_hp_rates/index.qmd
@@ -1625,7 +1625,7 @@ The cost composition of each side is very different. The vast majority of genera
 
 The delivery side is the opposite. As we saw above, the vast majority of transmission and distribution costs are {{< glossary "Embedded costs" display="embedded" >}} — the infrastructure is already built and has to be paid for regardless of what customers do. Only a small fraction of delivery costs are marginal: the next wave of capacity upgrades triggered by rising peak demand. A customer's delivery cost of service, and the delivery side of the bill that is supposed to collect it, is therefore dominated by their "fair share" of embedded costs, with marginal T&D costs adding a relatively small amount on top.
 
-## Rates
+## Rates {#sec-rates}
 
 Bills _attempt_ to recover each customer's cost of service — but they rarely succeed accurately, because bills are calculated using {{< glossary "Rates" display="rates" >}}, and rates are imperfect proxies for costs.
 
@@ -1750,8 +1750,56 @@ But it is possible to design rates that are both {{< glossary "Fairness problem"
 
 In fact, meeting the state's building electrification goals hinges on doing so: cost-based rates would lower heat pump bills by paying for _already built_ infrastructure more fairly, while cost-reflective rates could lower heat pump bills further by allowing customers to pre-cool and pre-heat their homes when electrons are cheap — while also reducing the amount of infrastructure the state will need to build as it electrifies, thereby limiting bill growth for all.
 
+# Appendix 2: Eliminating cross-subsidy by updating default rates
 
-# Appendix 2: Which households save when they switch to heat pumps? {#sec-savings}
+The {< glossary "Cost-based rate" display="cost-based" >} rates we analyzed in this report eliminate the {< glossary "Cross-subsidy" display="cross-subsidy" >} by creating rates that would only be available to heat pump customers (designs 1 and 3), and electric heating customers as a whole (design 2).
+
+But there is another approach: redesigning the default delivery rates that the vast majority of customers are already enrolled in.
+
+In this approach, there are two levers to pull: making the volumetric rate seasonal, and increasing the fixed charge. We analyze both approaches below.
+
+## Default delivery rates today
+Four of New York's utilities offer default delivery rates with {< glossary "Flat volumetric rates" display="flat volumetric charges" >} — the same price per kWh in every hour and every season (@tbl-elec-default-tariffs-flat-app2).
+
+:::::  {.column-body-outset-right}
+{{< embed notebooks/analysis.qmd#tbl-elec-default-tariffs-flat-app2 >}}
+:::::
+
+The three remaining utilities already use **seasonal default rates**: PSEG-LI offers a seasonal time-of-use rate as its default, and ConEd and O&R offer seasonal increasing-block rates with a 250 kWh/month threshold (@tbl-elec-default-tariffs-seasonal-app2).
+
+:::::  {.column-body-outset-right}
+{{< embed notebooks/analysis.qmd#tbl-elec-default-tariffs-seasonal-app2 >}}
+:::::
+
+This appendix focuses only on the four utilities with flat default delivery rates.
+
+## Seasonal volumetric rates
+
+When customers adopt heat pumps, the vast majority of their new electricity use occurs during the winter. Lowering the volumetric delivery rate in winter would therefore lower the average delivery bill of heat pump customers, reduce their overpayment and therefore reduce the cross-subsidy.
+
+However, every decrease in the default volumetric delivery rate in winter would require a corresponding increase in that rate during the summer, in order to avoid revenue shortfalls. @fig-rev-sufficient-rates shows the summer volumetric delivery rate would need to increase as the winter rate is lowered from the current flat rate, in order to keep each utility revenue-sufficient.
+
+::::: {.column-page-inset-right}
+{{< embed notebooks/fair_default_feasible_line.qmd#fig-rev-sufficient-rates >}}
+:::::
+
+As the winter delivery rate is lowered (and the summer rate is raised), to what extent would the cross-subsidy from heat pump to non-heat pump customers decrease? @fig-rev-sufficient-cross-subsidy has the answer.
+
+::::: {.column-page-inset-right}
+{{< embed notebooks/fair_default_feasible_line.qmd#fig-rev-sufficient-cross-subsidy >}}
+:::::
+
+Halving the volumetric delivery rates in winter would reduce the cross-subsidy by TK% to TK%, depending on the utility. Even making winter delivery rates $0/kWh (which would require making summer delivery rates between TK and TK, depending on the utility) would only reduce the cross-subsidy by TK% to TK%. 
+
+In other words: it is impossible to eliminate the cross-subsidy caused by default delivery rates by simply making them seasonal. The fixed charge must be increased as well.
+
+## Increasing the fixed charge
+
+In essence, utilities overcharge heat pump customers because they rely on volumetric rates to collect the vast majority of their delivery revenue. Volumetric rates assume that total electricity _usage_ drives infrastructure costs: that the more a household consumes, the more delivery costs they cause, and the more they should pay. As explained in @sec-rates, this assumption is false.
+
+Fixed delivery charges charge all customers the same amount infrastructure costs, regardless of how much electricity they consume. Raising each utility's fixed change will therefore have the effect of decreasing heat pump customer overpayments and reducing the cross-subsidy.
+
+# Appendix 3: Which households save when they switch to heat pumps? {#sec-savings}
 
 Under default rates, `{python} pct(v.pct_natgas_save_default_lmi40)` of gas-heated households would save on their annual energy bills after switching to a heat pump. What distinguishes these households from the rest? Two building characteristics stand out: the efficiency of the existing furnace or boiler, and whether the home already has air conditioning.
 
@@ -1761,7 +1809,7 @@ Homes with less efficient fossil heating systems — older furnaces and boilers 
 {{< embed notebooks/investigate_household_savings.qmd#fig-natgas-afue-cooling-pct-save-heatmap >}}
 :::
 
-# Appendix 3: Findings by utility
+# Appendix 4: Findings by utility
 
 
 ## Number of households

--- a/reports/ny_hp_rates/notebooks/analysis.qmd
+++ b/reports/ny_hp_rates/notebooks/analysis.qmd
@@ -3132,6 +3132,61 @@ _default_gt = (
 display_gt(_default_gt)
 ```
 
+```{python}
+#| label: app2-default-tariff-splits
+
+_flat_rows_app2 = [
+    {
+        "Utility": r["Utility"],
+        "Fixed charge ($/mo)": r["Fixed charge ($/mo)"],
+        "Delivery (¢/kWh)": r["Delivery (¢/kWh)"],
+    }
+    for r in _default_rows
+    if r["Season"] == "Monthly"
+]
+_flat_default_df_app2 = pl.DataFrame(_flat_rows_app2)
+
+_fixed_lookup_app2 = {
+    r["Utility"]: r["Fixed charge ($/mo)"]
+    for r in _default_rows
+    if r["Fixed charge ($/mo)"]
+}
+_seasonal_rows_app2 = [
+    {
+        "Utility": r["Utility"],
+        "Season": r["Season"],
+        "Fixed charge ($/mo)": _fixed_lookup_app2.get(r["Utility"], r["Fixed charge ($/mo)"]),
+        "Delivery (¢/kWh)": r["Delivery (¢/kWh)"],
+    }
+    for r in _default_rows
+    if r["Season"] != "Monthly"
+]
+_seasonal_default_df_app2 = pl.DataFrame(_seasonal_rows_app2)
+```
+
+```{python}
+#| label: tbl-elec-default-tariffs-flat-app2
+#| tbl-cap: "Default residential electric delivery tariffs for the four New York utilities with flat (non-seasonal) volumetric charges. Delivery includes the base rate-case delivery charge plus all volumetric surcharges topped up into the delivery revenue requirement. Where the volumetric rate varies by calendar month, the annual range is shown."
+
+_flat_gt_app2 = (
+    GT(_flat_default_df_app2)
+    .tab_options(**get_switchbox_gt_tab_options())
+)
+display_gt(_flat_gt_app2)
+```
+
+```{python}
+#| label: tbl-elec-default-tariffs-seasonal-app2
+#| tbl-cap: "Default residential electric delivery tariffs for the three New York utilities with seasonal default rates. Delivery includes the base rate-case delivery charge plus all volumetric surcharges topped up into the delivery revenue requirement."
+
+_seasonal_gt_app2 = (
+    GT(_seasonal_default_df_app2)
+    .tab_source_note("ConEd and O&R have increasing-block tiers with a 250 kWh/month threshold; '(first 250)' denotes the first-block rate. PSEG-LI has time-of-use rates; peak = weekday 3–7 PM, off-peak = all other hours and weekends.")
+    .tab_options(**get_switchbox_gt_tab_options())
+)
+display_gt(_seasonal_gt_app2)
+```
+
 
 ## Default gas tariffs
 

--- a/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
+++ b/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
@@ -1,0 +1,514 @@
+---
+title: Fair-Default Feasible Line Plots
+reference-location: margin
+fig-cap-location: bottom
+execute:
+  warning: false
+  message: false
+---
+
+This notebook plots the fixed-charge and seasonal-rate combinations that would eliminate the heat-pump cross-subsidy for each New York utility.
+It starts from the normal run 1 and run 2 CAIRO outputs: run 1 for delivery, and run 2 for delivery plus supply.
+
+The computation is imported from `rate-design-platform`.
+This notebook only resolves the run outputs, assembles the inputs, and renders the plots.
+For kWh totals, it always uses the local ResStock `load_curve_monthly` files.
+Volumetric rates from `rate-design-platform` are in `$/kWh`, matching the URDB tariff JSON `rate` fields.
+The plots display cents per kWh using the conversion `cents/kWh = $/kWh * 100`, so a `0.002 $/kWh` rate displays as `0.2¢/kWh`.
+
+## Setup
+
+```{python}
+#| label: setup
+
+from __future__ import annotations
+
+import math
+import os
+from pathlib import Path
+import sys
+
+import polars as pl
+from lib.data.s3 import list_s3_subdirs, run_dir
+from lib.plotnine import SB_COLORS, theme_switchbox
+from lib.quarto import display_svg
+from plotnine import (
+    aes,
+    facet_wrap,
+    geom_line,
+    geom_point,
+    geom_rect,
+    geom_segment,
+    geom_text,
+    ggplot,
+    labs,
+    scale_color_manual,
+    scale_linetype_manual,
+    scale_x_continuous,
+    scale_y_continuous,
+    theme,
+)
+
+CACHE_DIR = Path("../cache")
+CACHE_DIR.mkdir(exist_ok=True)
+POLARS_TEMP_DIR = CACHE_DIR / "polars"
+POLARS_TEMP_DIR.mkdir(exist_ok=True)
+os.environ.setdefault("POLARS_TEMP_DIR", str(POLARS_TEMP_DIR.resolve()))
+
+PATH_RDP = Path("/ebs/home/sherry_switch_box/rate-design-platform")
+sys.path.insert(0, str(PATH_RDP))
+
+from utils.mid.compute_fair_default_inputs import (  # noqa: E402
+    AffineLine,
+    FeasibleLineData,
+    StrategyPoint,
+    compute_feasible_line_from_runs,
+)
+```
+
+## Parameters
+
+```{python}
+#| label: params
+
+STATE = "NY"
+STATE_LOWER = STATE.lower()
+UPGRADE = "00"
+PATH_RESSTOCK = "/ebs/data/nrel/resstock/res_2024_amy2018_2"
+
+# Latest normal all-utility NY batch; only runs 1 and 2 are used.
+BATCH = "ny_20260417a_r1-36"
+RUN_DELIVERY_SUFFIX = "run1_up00_precalc__default"
+RUN_SUPPLY_SUFFIX = "run2_up00_precalc_supply__default"
+
+GROUP_COL = "has_hp"
+SUBCLASS_VALUE = "true"
+CROSS_SUBSIDY_COL = "BAT_percustomer"
+FIXED_CHARGE_FLOOR = 0.0
+
+UTIL_NAMES = {
+    "cenhud": "Central Hudson",
+    "coned": "Con Edison",
+    "nimo": "National Grid",
+    "nyseg": "NYSEG",
+    "or": "O&R",
+    "psegli": "PSEG-LI",
+    "rge": "RG&E",
+}
+UTIL_ORDER_CODES = ["psegli", "coned", "or", "cenhud", "nyseg", "rge", "nimo"]
+
+S3_OUTPUT_BASE = f"s3://data.sb/switchbox/cairo/outputs/hp_rates/{STATE_LOWER}"
+```
+
+## Feasible-Line Assembly
+
+For each utility, we resolve the run directories directly from S3 and delegate the actual feasible-line computation to `compute_feasible_line_from_runs` in `rate-design-platform`.
+Passing no marginal-cost seasonal ratio omits the marginal-cost seasonal-rate reform.
+The two closed-form points retained in the summary are the fixed-charge-only reform and the seasonal-rate-only reform.
+
+```{python}
+#| label: feasible-line-helpers
+
+
+def _resolve_utility_run_dirs(utility: str) -> dict[str, str]:
+    utility_base = f"{S3_OUTPUT_BASE}/{utility}/{BATCH}/"
+    subdirs = list_s3_subdirs(utility_base)
+    return {
+        "delivery": run_dir(subdirs, RUN_DELIVERY_SUFFIX),
+        "supply": run_dir(subdirs, RUN_SUPPLY_SUFFIX),
+    }
+
+
+def _base_tariff_path(utility: str, variant: str) -> Path:
+    suffix = "_supply" if variant == "supply" else ""
+    return PATH_RDP / f"rate_design/hp_rates/ny/config/tariffs/electric/{utility}_default{suffix}_calibrated.json"
+
+
+def _compute_feasible_lines_for_utility(utility: str) -> dict[str, FeasibleLineData]:
+    run_dirs = _resolve_utility_run_dirs(utility)
+    return compute_feasible_line_from_runs(
+        run_dir_delivery=run_dirs["delivery"],
+        run_dir_supply=run_dirs["supply"],
+        resstock_base=PATH_RESSTOCK,
+        state=STATE,
+        upgrade=UPGRADE,
+        path_base_tariff_delivery=_base_tariff_path(utility, "delivery"),
+        path_base_tariff_supply=_base_tariff_path(utility, "supply"),
+        group_col=GROUP_COL,
+        subclass_value=SUBCLASS_VALUE,
+        cross_subsidy_col=CROSS_SUBSIDY_COL,
+        fixed_charge_floor=FIXED_CHARGE_FLOOR,
+        title_delivery=f"{UTIL_NAMES[utility]} — Delivery",
+        title_supply=f"{UTIL_NAMES[utility]} — Supply",
+    )
+
+
+def _compute_all_feasible_lines() -> dict[str, dict[str, FeasibleLineData]]:
+    return {utility: _compute_feasible_lines_for_utility(utility) for utility in UTIL_ORDER_CODES}
+
+
+feasible_lines = _compute_all_feasible_lines()
+```
+
+Let's take a quick look at the fixed-charge range and reform points we computed for each utility.
+
+```{python}
+#| label: feasible-line-summary
+
+
+def _strategy_lookup(data: FeasibleLineData, label: str) -> StrategyPoint:
+    return next(sp for sp in data.strategies if sp.label == label)
+
+
+summary_rows = []
+for utility, utility_data in feasible_lines.items():
+    for variant, data in utility_data.items():
+        a = _strategy_lookup(data, "A")
+        b = _strategy_lookup(data, "B")
+        summary_rows.append(
+            {
+                "utility": utility,
+                "utility_label": UTIL_NAMES[utility],
+                "variant": variant,
+                "base_fixed_charge": data.base_fixed_charge,
+                "feasible_min": data.feasible_min,
+                "feasible_max": data.feasible_max,
+                "fixed_charge_only_reform_fixed_charge": a.fixed_charge,
+                "seasonal_rate_only_reform_fixed_charge": b.fixed_charge,
+                "winter_intercept": data.r_win.intercept,
+                "winter_slope": data.r_win.slope,
+                "summer_intercept": data.r_sum.intercept,
+                "summer_slope": data.r_sum.slope,
+            }
+        )
+
+summary = pl.DataFrame(summary_rows)
+summary
+```
+
+At the minimum feasible fixed charge, one of the seasonal volumetric rates is usually close to zero. The table below evaluates the feasible line at that minimum fixed charge for each utility.
+
+```{python}
+#| label: min-feasible-rate-table
+
+min_feasible_rows = []
+for utility, utility_data in feasible_lines.items():
+    for variant, data in utility_data.items():
+        min_fixed_charge = data.feasible_min
+        if data.feasible_exists and math.isfinite(min_fixed_charge):
+            winter_rate_cents_per_kwh = data.r_win.at(min_fixed_charge) * 100.0
+            summer_rate_cents_per_kwh = data.r_sum.at(min_fixed_charge) * 100.0
+        else:
+            winter_rate_cents_per_kwh = math.nan
+            summer_rate_cents_per_kwh = math.nan
+        min_feasible_rows.append(
+            {
+                "utility": UTIL_NAMES[utility],
+                "run": "Delivery only" if variant == "delivery" else "Delivery + supply",
+                "min_feasible_fixed_charge_$_per_month": min_fixed_charge,
+                "winter_rate_cents_per_kwh": winter_rate_cents_per_kwh,
+                "summer_rate_cents_per_kwh": summer_rate_cents_per_kwh,
+            }
+        )
+
+min_feasible_rates = (
+    pl.DataFrame(min_feasible_rows)
+    .with_columns(
+        pl.col("utility").cast(pl.Enum([UTIL_NAMES[utility] for utility in UTIL_ORDER_CODES])),
+        pl.col("run").cast(pl.Enum(["Delivery only", "Delivery + supply"])),
+    )
+    .sort("utility", "run")
+)
+min_feasible_rates
+```
+
+## Plot Helpers
+
+The plotting helpers below mirror the RDP plotting module's fixed-charge sweep.
+The line panels do not mark reform points; the summary table above labels them as the fixed-charge-only reform and the seasonal-rate-only reform.
+
+```{python}
+#| label: plot-helpers
+
+_INF = math.inf
+_STRATEGY_COLORS = {
+    "A": SB_COLORS["carrot"],
+    "B": SB_COLORS["midnight"],
+}
+
+
+def _verify_affine_vs_strategies(data: FeasibleLineData) -> None:
+    tol = 1e-6
+    for sp in data.strategies:
+        if sp.label == "A":
+            continue
+        computed_win = data.r_win.at(sp.fixed_charge)
+        computed_sum = data.r_sum.at(sp.fixed_charge)
+        if sp.winter_rate is not None and not math.isnan(sp.winter_rate):
+            assert abs(computed_win - sp.winter_rate) <= tol
+        if sp.summer_rate is not None and not math.isnan(sp.summer_rate):
+            assert abs(computed_sum - sp.summer_rate) <= tol
+
+
+def _sweep_range(data: FeasibleLineData, f_min: float | None = None, f_max: float | None = None) -> tuple[float, float]:
+    fc_floor = max(0.0, data.fixed_charge_floor)
+    r_sum_zero = data.r_sum.zero_crossing()
+    r_win_zero = data.r_win.zero_crossing()
+    natural_upper = max(
+        data.feasible_max if math.isfinite(data.feasible_max) else 0.0,
+        r_sum_zero if (math.isfinite(r_sum_zero) and r_sum_zero > 0) else 0.0,
+        r_win_zero if (math.isfinite(r_win_zero) and r_win_zero > 0) else 0.0,
+    )
+    for sp in data.strategies:
+        if math.isfinite(sp.fixed_charge):
+            natural_upper = max(natural_upper, sp.fixed_charge)
+    lo = f_min if f_min is not None else max(20.0, fc_floor)
+    hi = f_max if f_max is not None else natural_upper + 10.0
+    if hi <= lo:
+        hi = lo + 20.0
+    return lo, hi
+
+
+def _linspace(lo: float, hi: float, n: int = 300) -> list[float]:
+    step = (hi - lo) / (n - 1)
+    return [lo + i * step for i in range(n)]
+
+
+def _rate_cents_per_kwh(rate_dollars_per_kwh: float) -> float:
+    return rate_dollars_per_kwh * 100.0
+
+
+def _strategy_rate(data: FeasibleLineData, strategy: StrategyPoint, line: AffineLine, stored_rate: float | None) -> float:
+    if stored_rate is not None and not math.isnan(stored_rate):
+        return _rate_cents_per_kwh(stored_rate)
+    return _rate_cents_per_kwh(line.at(strategy.fixed_charge))
+
+
+def _plot_frames(data: FeasibleLineData) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    lo, hi = _sweep_range(data)
+    fs = _linspace(lo, hi)
+    line_rows = []
+    for f in fs:
+        line_rows.extend(
+            [
+                {"fixed_charge": f, "rate_cents_per_kwh": _rate_cents_per_kwh(data.r_win.at(f)), "season": "Winter"},
+                {"fixed_charge": f, "rate_cents_per_kwh": _rate_cents_per_kwh(data.r_sum.at(f)), "season": "Summer"},
+            ]
+        )
+    strategy_rows = []
+    for sp in data.strategies:
+        if sp.label not in {"A", "B"} or not math.isfinite(sp.fixed_charge):
+            continue
+        strategy_rows.extend(
+            [
+                {
+                    "fixed_charge": sp.fixed_charge,
+                    "rate_cents_per_kwh": _strategy_rate(data, sp, data.r_win, sp.winter_rate),
+                    "season": "Winter",
+                    "strategy": f"Strategy {sp.label}",
+                    "label": sp.label,
+                    "feasible": sp.feasible,
+                },
+                {
+                    "fixed_charge": sp.fixed_charge,
+                    "rate_cents_per_kwh": _strategy_rate(data, sp, data.r_sum, sp.summer_rate),
+                    "season": "Summer",
+                    "strategy": f"Strategy {sp.label}",
+                    "label": sp.label,
+                    "feasible": sp.feasible,
+                },
+            ]
+        )
+    line_df = pl.DataFrame(line_rows)
+    strategy_df = pl.DataFrame(strategy_rows)
+    y_min = min(float(line_df["rate_cents_per_kwh"].min()), 0.0)
+    y_max = max(float(line_df["rate_cents_per_kwh"].max()), 0.0)
+    y_pad = max((y_max - y_min) * 0.08, 0.5)
+    feas_lo = max(data.feasible_min if math.isfinite(data.feasible_min) else lo, lo)
+    feas_hi = min(data.feasible_max if math.isfinite(data.feasible_max) else hi, hi)
+    rect_df = pl.DataFrame(
+        [
+            {
+                "xmin": feas_lo,
+                "xmax": feas_hi,
+                "ymin": y_min - y_pad,
+                "ymax": y_max + y_pad,
+            }
+        ]
+        if data.feasible_exists and feas_hi > feas_lo
+        else []
+    )
+    return line_df, strategy_df, rect_df
+
+
+def _all_plot_frames() -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    line_frames = []
+    strategy_frames = []
+    rect_frames = []
+    range_rows = []
+    for utility in UTIL_ORDER_CODES:
+        for variant, data in feasible_lines[utility].items():
+            _verify_affine_vs_strategies(data)
+            line_df, strategy_df, rect_df = _plot_frames(data)
+            variant_label = "Delivery only" if variant == "delivery" else "Delivery + supply"
+            context = {
+                "utility": utility,
+                "utility_label": UTIL_NAMES[utility],
+                "variant": variant_label,
+            }
+            line_frames.append(line_df.with_columns(**{key: pl.lit(value) for key, value in context.items()}))
+            strategy_frames.append(strategy_df.with_columns(**{key: pl.lit(value) for key, value in context.items()}))
+            if rect_df.height:
+                rect_frames.append(rect_df.with_columns(**{key: pl.lit(value) for key, value in context.items()}))
+            range_rows.append(
+                {
+                    **context,
+                    "feasible_min": data.feasible_min,
+                    "feasible_max": data.feasible_max,
+                    "feasible_exists": data.feasible_exists,
+                }
+            )
+
+    return (
+        pl.concat(line_frames),
+        pl.concat(strategy_frames),
+        pl.concat(rect_frames) if rect_frames else pl.DataFrame(),
+        pl.DataFrame(range_rows),
+    )
+
+
+line_all, strategy_all, rect_all, range_all = _all_plot_frames()
+
+
+def _ordered_plot_frames(
+    variant: str,
+    utility_codes: list[str],
+) -> tuple[pl.DataFrame, pl.DataFrame]:
+    utility_labels = [UTIL_NAMES[utility] for utility in utility_codes]
+    utility_dtype = pl.Enum(utility_labels)
+    season_dtype = pl.Enum(["Winter", "Summer"])
+    line_df = (
+        line_all.filter(
+            (pl.col("variant") == variant)
+            & (pl.col("utility").is_in(utility_codes))
+        )
+        .with_columns(
+            pl.col("utility_label").cast(utility_dtype),
+            pl.col("season").cast(season_dtype),
+        )
+    )
+    rect_df = (
+        rect_all.filter(
+            (pl.col("variant") == variant)
+            & (pl.col("utility").is_in(utility_codes))
+        )
+        .with_columns(pl.col("utility_label").cast(utility_dtype))
+    )
+    return line_df, rect_df
+
+
+def plot_multi_utility_feasible_grid(variant: str, utility_codes: list[str], title: str):
+    line_df, rect_df = _ordered_plot_frames(variant, utility_codes)
+    p = (
+        ggplot(line_df, aes("fixed_charge", "rate_cents_per_kwh", color="season", linetype="season"))
+        + geom_rect(
+            rect_df,
+            aes(xmin="xmin", xmax="xmax", ymin="ymin", ymax="ymax"),
+            inherit_aes=False,
+            fill=SB_COLORS["pistachio"],
+            alpha=0.13,
+            color="none",
+        )
+        + geom_line(size=0.85)
+        + facet_wrap("utility_label", ncol=2, scales="free")
+        + scale_color_manual(values={"Winter": SB_COLORS["midnight"], "Summer": SB_COLORS["carrot"]})
+        + scale_linetype_manual(values={"Winter": "solid", "Summer": "dashed"})
+        + scale_x_continuous(labels=lambda breaks: [f"${b:,.0f}" for b in breaks])
+        + scale_y_continuous(labels=lambda breaks: [f"{b:,.2f}¢/kWh" for b in breaks])
+        + labs(
+            title=title,
+            subtitle="Each line shows the seasonal volumetric rate implied by a fixed-charge choice; the green band marks the feasible fixed-charge range.",
+            x="Fixed charge",
+            y="Volumetric rate",
+            color="Season",
+            linetype="Season",
+        )
+        + theme_switchbox()
+        + theme(figure_size=(12.5, 13.5), legend_position="bottom")
+    )
+    fig = p.draw()
+    display_svg(fig)
+
+
+def plot_feasible_fixed_charge_ranges(variant: str, title: str):
+    ranges = range_all.filter((pl.col("feasible_exists")) & (pl.col("variant") == variant))
+    p = (
+        ggplot(ranges, aes("utility_label", "feasible_min"))
+        + geom_segment(
+            aes(x="utility_label", xend="utility_label", y="feasible_min", yend="feasible_max"),
+            size=2.2,
+            lineend="round",
+            color=SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"],
+        )
+        + geom_point(
+            size=2.7,
+            color=SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"],
+        )
+        + geom_point(
+            aes(y="feasible_max"),
+            size=2.7,
+            color=SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"],
+        )
+        + scale_y_continuous(labels=lambda breaks: [f"${b:,.0f}" for b in breaks])
+        + labs(
+            title=title,
+            subtitle="Vertical ranges show the fixed charges for which both winter and summer volumetric rates are non-negative.",
+            x="Utility",
+            y="Fixed charge",
+        )
+        + theme_switchbox()
+        + theme(figure_size=(10.5, 7.0), legend_position="none")
+    )
+    fig = p.draw()
+    display_svg(fig)
+```
+
+## Feasible Seasonal Rates
+
+```{python}
+#| label: fig-feasible-lines-delivery
+#| fig-cap: "Feasible fixed-charge and seasonal delivery-rate combinations for each New York utility."
+
+plot_multi_utility_feasible_grid(
+    "Delivery only",
+    UTIL_ORDER_CODES,
+    "Feasible fair-default delivery rates by utility",
+)
+```
+
+```{python}
+#| label: fig-feasible-lines-delivery-supply
+#| fig-cap: "Feasible fixed-charge and seasonal delivery-plus-supply rate combinations for each New York utility."
+
+plot_multi_utility_feasible_grid(
+    "Delivery + supply",
+    UTIL_ORDER_CODES,
+    "Feasible fair-default delivery-plus-supply rates by utility",
+)
+```
+
+## Feasible Fixed-Charge Ranges
+
+```{python}
+#| label: fig-feasible-fixed-charge-ranges-delivery
+#| fig-cap: "Feasible default fixed-charge ranges by utility for delivery rates."
+
+plot_feasible_fixed_charge_ranges("Delivery only", "Feasible default delivery fixed-charge ranges")
+```
+
+```{python}
+#| label: fig-feasible-fixed-charge-ranges-delivery-supply
+#| fig-cap: "Feasible default fixed-charge ranges by utility for delivery-plus-supply rates."
+
+plot_feasible_fixed_charge_ranges("Delivery + supply", "Feasible default delivery-plus-supply fixed-charge ranges")
+```

--- a/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
+++ b/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
@@ -36,6 +36,7 @@ from lib.quarto import display_svg
 from plotnine import (
     aes,
     facet_wrap,
+    geom_label,
     geom_line,
     geom_point,
     geom_rect,
@@ -860,10 +861,6 @@ def plot_revenue_sufficient_cross_subsidy(
     title: str,
 ):
     _, cross_subsidy_df, endpoint_df = _revenue_sufficient_plot_frames(variant, utility_codes)
-    y_min_raw = min(float(cross_subsidy_df["cross_subsidy_per_customer"].min()), 0.0)
-    y_max_raw = max(float(cross_subsidy_df["cross_subsidy_per_customer"].max()), 0.0)
-    y_span = max(y_max_raw - y_min_raw, 1.0)
-    y_limits = (y_min_raw - 0.08 * y_span, y_max_raw + 0.12 * y_span)
     zero_line_df = (
         cross_subsidy_df.group_by("utility_label", maintain_order=True)
         .agg(
@@ -891,23 +888,26 @@ def plot_revenue_sufficient_cross_subsidy(
             color=SB_COLORS["carrot"],
             size=2.3,
         )
-        + geom_text(
+        + geom_label(
             endpoint_df,
             aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer", label="label"),
             inherit_aes=False,
             color=SB_COLORS["carrot"],
+            fill="white",
+            label_size=0.25,
+            label_padding=0.12,
             size=8,
             ha="left",
             va="center",
-            nudge_x=0.25,
+            nudge_x=0.35,
         )
-        + facet_wrap("utility_label", ncol=2, scales="free_x")
+        + facet_wrap("utility_label", ncol=2, scales="free")
         + scale_x_continuous(
             expand=(0, 0, 0.08, 0),
             labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
         )
         + scale_y_continuous(
-            limits=y_limits,
+            expand=(0.08, 0, 0.16, 0),
             labels=lambda breaks: [f"${b:,.0f}" for b in breaks],
         )
         + labs(
@@ -936,17 +936,6 @@ plot_multi_utility_feasible_grid(
 )
 ```
 
-```{python}
-#| label: fig-feasible-lines-delivery-supply
-#| fig-cap: "Feasible fixed-charge and seasonal delivery-plus-supply rate combinations for each New York utility."
-
-plot_multi_utility_feasible_grid(
-    "Delivery + supply",
-    UTIL_ORDER_CODES,
-    "Feasible fair-default delivery-plus-supply rates by utility",
-)
-```
-
 ## Zoomed Feasible Seasonal Rates
 
 ```{python}
@@ -961,18 +950,6 @@ plot_multi_utility_feasible_grid(
 )
 ```
 
-```{python}
-#| label: fig-feasible-lines-delivery-supply-zoomed
-#| fig-cap: "Zoomed feasible fixed-charge and seasonal delivery-plus-supply rate combinations for each New York utility."
-
-plot_multi_utility_feasible_grid(
-    "Delivery + supply",
-    UTIL_ORDER_CODES,
-    "Zoomed feasible fair-default delivery-plus-supply rates by utility",
-    zoom_to_feasible_range=True,
-)
-```
-
 ## Feasible Fixed-Charge Ranges
 
 ```{python}
@@ -980,13 +957,6 @@ plot_multi_utility_feasible_grid(
 #| fig-cap: "Feasible default fixed-charge ranges by utility for delivery rates."
 
 plot_feasible_fixed_charge_ranges("Delivery only", "Feasible default delivery fixed-charge ranges")
-```
-
-```{python}
-#| label: fig-feasible-fixed-charge-ranges-delivery-supply
-#| fig-cap: "Feasible default fixed-charge ranges by utility for delivery-plus-supply rates."
-
-plot_feasible_fixed_charge_ranges("Delivery + supply", "Feasible default delivery-plus-supply fixed-charge ranges")
 ```
 
 ## Revenue-Sufficient Seasonal Sweep

--- a/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
+++ b/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
@@ -45,11 +45,47 @@ from plotnine import (
     ggplot,
     labs,
     scale_color_manual,
+    scale_fill_manual,
     scale_linetype_manual,
     scale_x_continuous,
+    scale_x_reverse,
     scale_y_continuous,
     theme,
 )
+
+
+def _integer_cent_breaks(limits: tuple[float, float]) -> list[int]:
+    """Minor breaks: every 1 cent, integer values, within the data limits."""
+    lo, hi = float(min(limits)), float(max(limits))
+    lo_int = int(math.floor(lo))
+    hi_int = int(math.ceil(hi))
+    return list(range(lo_int, hi_int + 1))
+
+
+def _major_5c_breaks(limits: tuple[float, float]) -> list[int]:
+    """Major breaks every 5 cents, snapped to multiples of 5, within the data limits.
+
+    Used for both ¢/kWh axes (volumetric rates) so labels don't overlap on
+    facets whose data range spans 10+ cents.
+    """
+    lo, hi = float(min(limits)), float(max(limits))
+    lo_int = int(math.floor(lo / 5.0)) * 5
+    hi_int = int(math.ceil(hi / 5.0)) * 5
+    return list(range(lo_int, hi_int + 1, 5))
+
+
+def _cent_label(breaks: list[float]) -> list[str]:
+    """Compact ¢/kWh tick label for axes with integer breaks ('5¢/kWh')."""
+    return [f"{b:.0f}¢/kWh" for b in breaks]
+
+
+def _pct_25_breaks(limits: tuple[float, float]) -> list[int]:
+    """Major breaks every 25 percentage points within the data limits."""
+    lo, hi = float(min(limits)), float(max(limits))
+    lo_int = int(math.floor(lo / 25.0)) * 25
+    hi_int = int(math.ceil(hi / 25.0)) * 25
+    return list(range(lo_int, hi_int + 1, 25))
+
 
 CACHE_DIR = Path("../cache")
 CACHE_DIR.mkdir(exist_ok=True)
@@ -876,7 +912,7 @@ def plot_revenue_sufficient_rates(
             inherit_aes=False,
             color=SB_COLORS["sky"],
             size=8,
-            ha="right",
+            ha="left",
             va="bottom",
             nudge_x=-0.25,
             nudge_y=0.35,
@@ -894,18 +930,22 @@ def plot_revenue_sufficient_rates(
                 "Summer": "dashed",
             }
         )
-        + scale_x_continuous(
-            expand=(0, 0, 0.08, 0),
-            labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
+        + scale_x_reverse(
+            breaks=_major_5c_breaks,
+            minor_breaks=_integer_cent_breaks,
+            expand=(0.04, 0, 0.08, 0),
+            labels=_cent_label,
         )
         + scale_y_continuous(
+            breaks=_major_5c_breaks,
+            minor_breaks=_integer_cent_breaks,
             expand=(0, 0, 0.12, 0),
-            labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
+            labels=_cent_label,
         )
         + labs(
             title=title,
             subtitle="At the current fixed charge, winter rates are swept down from the current flat rate; summer rates rise to maintain revenue sufficiency. Cost-reflective MC seasonal marker is an outstanding follow-up.",
-            x="Winter volumetric rate",
+            x="Winter volumetric rate (lower → right)",
             y="Volumetric rate",
             color="",
             linetype="",
@@ -921,8 +961,51 @@ def plot_revenue_sufficient_cross_subsidy(
     variant: str,
     utility_codes: list[str],
     title: str,
+    only_current_fixed_charge: bool = False,
 ):
     _, cross_subsidy_df, endpoint_df = _revenue_sufficient_plot_frames(variant, utility_codes)
+
+    # Baseline = current cross-subsidy per utility = max of "Current fixed charge" line.
+    # Computed before filtering so the all-lines and current-only views share a y scale.
+    baseline_df = (
+        cross_subsidy_df.filter(pl.col("fixed_charge_level") == "Current fixed charge")
+        .group_by("utility_label", maintain_order=True)
+        .agg(pl.col("cross_subsidy_per_customer").max().alias("baseline_cs"))
+    )
+
+    cross_subsidy_df = cross_subsidy_df.join(baseline_df, on="utility_label").with_columns(
+        (pl.col("cross_subsidy_per_customer") / pl.col("baseline_cs") * 100).alias("cs_pct"),
+        # Compact "$45/mo" label without the " (min feasible)" suffix that the
+        # endpoint label used to carry.
+        pl.format("${}/mo", pl.col("fixed_charge").round(0).cast(pl.Int64)).alias("fc_short_label"),
+    )
+    endpoint_df = endpoint_df.join(baseline_df, on="utility_label").with_columns(
+        (pl.col("cross_subsidy_per_customer") / pl.col("baseline_cs") * 100).alias("cs_pct"),
+        pl.format("${}", pl.col("cross_subsidy_per_customer").round(0).cast(pl.Int64)).alias("endpoint_label"),
+    )
+
+    # Midpoint of each (utility, fixed_charge_level) line, used for the
+    # prominent fixed-charge label.
+    midpoint_df = (
+        cross_subsidy_df.with_columns(
+            (
+                pl.col("winter_rate_cents_per_kwh")
+                - pl.col("winter_rate_cents_per_kwh").mean().over("utility_label", "fixed_charge_level")
+            )
+            .abs()
+            .alias("dist_from_mean")
+        )
+        .sort("utility_label", "fixed_charge_level", "dist_from_mean")
+        .group_by(["utility_label", "fixed_charge_level"], maintain_order=True)
+        .first()
+        .drop("dist_from_mean")
+    )
+
+    if only_current_fixed_charge:
+        cross_subsidy_df = cross_subsidy_df.filter(pl.col("fixed_charge_level") == "Current fixed charge")
+        endpoint_df = endpoint_df.filter(pl.col("fixed_charge_level") == "Current fixed charge")
+        midpoint_df = midpoint_df.filter(pl.col("fixed_charge_level") == "Current fixed charge")
+
     zero_line_df = (
         cross_subsidy_df.group_by("utility_label", maintain_order=True)
         .agg(
@@ -932,12 +1015,23 @@ def plot_revenue_sufficient_cross_subsidy(
         .with_columns(pl.lit(0.0).alias("y"))
     )
 
+    subtitle = (
+        "100% = each utility's current heat-pump cross-subsidy. "
+        "Midpoint pill on each line is the monthly fixed charge; endpoint label is the residual cross-subsidy "
+        "per customer at a zero winter rate."
+    )
+    if only_current_fixed_charge:
+        subtitle = (
+            "Holding each utility's current default fixed charge, this is the residual heat-pump cross-subsidy "
+            "as the winter delivery rate is lowered from today's flat rate to zero. " + subtitle
+        )
+
     p = (
         ggplot(
             cross_subsidy_df,
             aes(
                 "winter_rate_cents_per_kwh",
-                "cross_subsidy_per_customer",
+                "cs_pct",
                 color="fixed_charge_level",
             ),
         )
@@ -952,43 +1046,60 @@ def plot_revenue_sufficient_cross_subsidy(
         + geom_line(size=0.9)
         + geom_point(
             endpoint_df,
-            aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer", color="fixed_charge_level"),
+            aes("winter_rate_cents_per_kwh", "cs_pct", color="fixed_charge_level"),
             inherit_aes=False,
-            size=2.3,
+            size=2.0,
         )
-        + geom_label(
+        + geom_text(
             endpoint_df,
             aes(
                 "winter_rate_cents_per_kwh",
-                "cross_subsidy_per_customer",
-                label="label",
+                "cs_pct",
+                label="endpoint_label",
                 color="fixed_charge_level",
             ),
             inherit_aes=False,
-            fill="white",
-            label_size=0.25,
-            label_padding=0.12,
-            size=8,
-            ha="left",
+            size=7,
+            ha="right",
             va="center",
             nudge_x=0.35,
         )
-        + facet_wrap("utility_label", ncol=2, scales="free")
-        + scale_x_continuous(
-            expand=(0, 0, 0.08, 0),
-            labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
+        + geom_label(
+            midpoint_df,
+            aes(
+                "winter_rate_cents_per_kwh",
+                "cs_pct",
+                label="fc_short_label",
+                fill="fixed_charge_level",
+            ),
+            inherit_aes=False,
+            color="white",
+            fontweight="bold",
+            size=10,
+            label_padding=0.22,
+            label_size=0,
+        )
+        + facet_wrap("utility_label", ncol=2, scales="free_x")
+        + scale_x_reverse(
+            breaks=_major_5c_breaks,
+            minor_breaks=_integer_cent_breaks,
+            expand=(0.04, 0, 0.08, 0),
+            labels=_cent_label,
         )
         + scale_y_continuous(
-            expand=(0.08, 0, 0.16, 0),
-            labels=lambda breaks: [f"${b:,.0f}" for b in breaks],
+            breaks=_pct_25_breaks,
+            expand=(0.06, 0, 0.18, 0),
+            labels=lambda breaks: [f"{b:.0f}%" for b in breaks],
         )
         + scale_color_manual(values=_FIXED_CHARGE_COLORS)
+        + scale_fill_manual(values=_FIXED_CHARGE_COLORS)
         + labs(
             title=title,
-            subtitle="Positive values mean heat-pump customers are overpaying relative to their BAT benchmark. Dotted lines mark zero; endpoint labels show the residual at a zero winter rate.",
-            x="Winter volumetric rate",
-            y="Cross-subsidy per heat-pump customer",
+            subtitle=subtitle,
+            x="Winter volumetric rate (lower → right)",
+            y="Cross-subsidy (% of today's level)",
             color="Fixed charge",
+            fill="Fixed charge",
         )
         + theme_switchbox()
         + theme(figure_size=(12.5, 13.5), legend_position="bottom")
@@ -1043,23 +1154,42 @@ The cost-reflective seasonal marker is intentionally left out for now.
 Adding it requires carrying the marginal-cost seasonal ratio into this notebook or persisting it with the run outputs.
 
 ```{python}
+#| label: rev-sufficient-utils
+
+# PSEG-LI, Con Edison, and O&R are excluded from the revenue-sufficient sweep plots.
+REV_SUFFICIENT_UTIL_CODES = [u for u in UTIL_ORDER_CODES if u not in {"psegli", "coned", "or"}]
+```
+
+```{python}
 #| label: fig-rev-sufficient-rates
 #| fig-cap: "Revenue-sufficient delivery-rate pairs as the winter rate is lowered from the current default rate."
 
 plot_revenue_sufficient_rates(
     "Delivery only",
-    UTIL_ORDER_CODES,
+    REV_SUFFICIENT_UTIL_CODES,
     "Revenue-sufficient seasonal delivery rates by utility",
 )
 ```
 
 ```{python}
-#| label: fig-rev-sufficient-cross-subsidy
-#| fig-cap: "Residual heat-pump cross-subsidy under revenue-sufficient seasonal delivery rates."
+#| label: fig-rev-sufficient-cross-subsidy-current
+#| fig-cap: "Residual heat-pump cross-subsidy at the current fixed charge as the winter delivery rate is lowered."
 
 plot_revenue_sufficient_cross_subsidy(
     "Delivery only",
-    UTIL_ORDER_CODES,
+    REV_SUFFICIENT_UTIL_CODES,
+    "Cross-subsidy remaining at the current fixed charge",
+    only_current_fixed_charge=True,
+)
+```
+
+```{python}
+#| label: fig-rev-sufficient-cross-subsidy
+#| fig-cap: "Residual heat-pump cross-subsidy under revenue-sufficient seasonal delivery rates, across a range of fixed charges."
+
+plot_revenue_sufficient_cross_subsidy(
+    "Delivery only",
+    REV_SUFFICIENT_UTIL_CODES,
     "Cross-subsidy remaining after revenue-sufficient seasonal differentiation",
 )
 ```

--- a/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
+++ b/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
@@ -27,6 +27,7 @@ import math
 import os
 from pathlib import Path
 import sys
+import importlib
 
 import polars as pl
 from lib.data.s3 import list_s3_subdirs, run_dir
@@ -58,12 +59,16 @@ os.environ.setdefault("POLARS_TEMP_DIR", str(POLARS_TEMP_DIR.resolve()))
 PATH_RDP = Path("/ebs/home/sherry_switch_box/rate-design-platform")
 sys.path.insert(0, str(PATH_RDP))
 
-from utils.mid.compute_fair_default_inputs import (  # noqa: E402
-    AffineLine,
-    FeasibleLineData,
-    StrategyPoint,
-    compute_feasible_line_from_runs,
-)
+from utils.mid import compute_fair_default_inputs as fair_default_inputs  # noqa: E402
+
+fair_default_inputs = importlib.reload(fair_default_inputs)
+
+AffineLine = fair_default_inputs.AffineLine
+FeasibleLineData = fair_default_inputs.FeasibleLineData
+RevenueSufficientLineData = fair_default_inputs.RevenueSufficientLineData
+StrategyPoint = fair_default_inputs.StrategyPoint
+compute_feasible_line_from_runs = fair_default_inputs.compute_feasible_line_from_runs
+compute_revenue_sufficient_line_from_runs = fair_default_inputs.compute_revenue_sufficient_line_from_runs
 ```
 
 ## Parameters
@@ -147,7 +152,31 @@ def _compute_all_feasible_lines() -> dict[str, dict[str, FeasibleLineData]]:
     return {utility: _compute_feasible_lines_for_utility(utility) for utility in UTIL_ORDER_CODES}
 
 
+def _compute_revenue_sufficient_lines_for_utility(utility: str) -> dict[str, RevenueSufficientLineData]:
+    run_dirs = _resolve_utility_run_dirs(utility)
+    return compute_revenue_sufficient_line_from_runs(
+        run_dir_delivery=run_dirs["delivery"],
+        run_dir_supply=run_dirs["supply"],
+        resstock_base=PATH_RESSTOCK,
+        state=STATE,
+        upgrade=UPGRADE,
+        path_base_tariff_delivery=_base_tariff_path(utility, "delivery"),
+        path_base_tariff_supply=_base_tariff_path(utility, "supply"),
+        group_col=GROUP_COL,
+        subclass_value=SUBCLASS_VALUE,
+        cross_subsidy_col=CROSS_SUBSIDY_COL,
+        fixed_charge_floor=FIXED_CHARGE_FLOOR,
+        title_delivery=f"{UTIL_NAMES[utility]} — Delivery revenue sufficiency",
+        title_supply=f"{UTIL_NAMES[utility]} — Delivery + supply revenue sufficiency",
+    )
+
+
+def _compute_all_revenue_sufficient_lines() -> dict[str, dict[str, RevenueSufficientLineData]]:
+    return {utility: _compute_revenue_sufficient_lines_for_utility(utility) for utility in UTIL_ORDER_CODES}
+
+
 feasible_lines = _compute_all_feasible_lines()
+revenue_sufficient_lines = _compute_all_revenue_sufficient_lines()
 ```
 
 Let's take a quick look at the fixed-charge range and reform points we computed for each utility.
@@ -433,8 +462,142 @@ def _ordered_plot_frames(
 _LEGEND_CURRENT = "Current rate"
 
 
-def plot_multi_utility_feasible_grid(variant: str, utility_codes: list[str], title: str):
-    line_df, rect_df, vline_df = _ordered_plot_frames(variant, utility_codes)
+def _zoom_sweep_range(data: FeasibleLineData) -> tuple[float, float]:
+    if (
+        not data.feasible_exists
+        or not math.isfinite(data.feasible_min)
+        or not math.isfinite(data.feasible_max)
+        or data.feasible_max <= data.feasible_min
+    ):
+        return _sweep_range(data)
+
+    return data.feasible_min, data.feasible_max
+
+
+def _zoom_plot_frames(
+    variant: str,
+    utility_codes: list[str],
+) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    line_frames = []
+    rect_frames = []
+    vline_frames = []
+    utility_labels = [UTIL_NAMES[utility] for utility in utility_codes]
+    utility_dtype = pl.Enum(utility_labels)
+    season_dtype = pl.Enum(["Winter", "Summer"])
+
+    for utility in utility_codes:
+        variant_key = next(
+            key
+            for key in feasible_lines[utility]
+            if ("Delivery only" if key == "delivery" else "Delivery + supply") == variant
+        )
+        data = feasible_lines[utility][variant_key]
+        lo, hi = _zoom_sweep_range(data)
+        fs = _linspace(lo, hi)
+        line_rows = []
+        for f in fs:
+            line_rows.extend(
+                [
+                    {"fixed_charge": f, "rate_cents_per_kwh": _rate_cents_per_kwh(data.r_win.at(f)), "season": "Winter"},
+                    {"fixed_charge": f, "rate_cents_per_kwh": _rate_cents_per_kwh(data.r_sum.at(f)), "season": "Summer"},
+                ]
+            )
+
+        line_df = pl.DataFrame(line_rows)
+        y_min = float(line_df["rate_cents_per_kwh"].min())
+        y_max = float(line_df["rate_cents_per_kwh"].max())
+        y_pad = max((y_max - y_min) * 0.08, 0.25)
+        y_lo = y_min - y_pad
+        y_hi = y_max + y_pad
+        context = {
+            "utility": utility,
+            "utility_label": UTIL_NAMES[utility],
+            "variant": variant,
+        }
+        line_frames.append(
+            line_df.with_columns(
+                pl.col("season").cast(season_dtype),
+                **{key: pl.lit(value) for key, value in context.items()},
+            )
+        )
+
+        if data.feasible_exists and math.isfinite(data.feasible_min) and math.isfinite(data.feasible_max):
+            rect_frames.append(
+                pl.DataFrame(
+                    [
+                        {
+                            **context,
+                            "xmin": max(data.feasible_min, lo),
+                            "xmax": min(data.feasible_max, hi),
+                            "ymin": y_lo,
+                            "ymax": y_hi,
+                        }
+                    ]
+                )
+            )
+
+        # Keep the current-rate marker only when it falls inside the zoomed window.
+        if math.isfinite(data.base_fixed_charge) and lo <= data.base_fixed_charge <= hi:
+            vline_frames.append(
+                pl.DataFrame(
+                    [
+                        {
+                            **context,
+                            "xintercept": data.base_fixed_charge,
+                            "label": f"${data.base_fixed_charge:,.0f}/mo",
+                            "y_lo": y_lo,
+                            "y_hi": y_hi,
+                        }
+                    ]
+                )
+            )
+
+    line_df = pl.concat(line_frames).with_columns(pl.col("utility_label").cast(utility_dtype))
+    rect_df = (
+        pl.concat(rect_frames).with_columns(pl.col("utility_label").cast(utility_dtype))
+        if rect_frames
+        else pl.DataFrame(
+            schema={
+                "utility": pl.Utf8,
+                "utility_label": pl.Utf8,
+                "variant": pl.Utf8,
+                "xmin": pl.Float64,
+                "xmax": pl.Float64,
+                "ymin": pl.Float64,
+                "ymax": pl.Float64,
+            }
+        )
+    )
+    vline_df = (
+        pl.concat(vline_frames).with_columns(pl.col("utility_label").cast(utility_dtype))
+        if vline_frames
+        else pl.DataFrame(
+            schema={
+                "utility": pl.Utf8,
+                "utility_label": pl.Utf8,
+                "variant": pl.Utf8,
+                "xintercept": pl.Float64,
+                "label": pl.Utf8,
+                "y_lo": pl.Float64,
+                "y_hi": pl.Float64,
+            }
+        )
+    )
+    return line_df, rect_df, vline_df
+
+
+def plot_multi_utility_feasible_grid(
+    variant: str,
+    utility_codes: list[str],
+    title: str,
+    *,
+    zoom_to_feasible_range: bool = False,
+):
+    line_df, rect_df, vline_df = (
+        _zoom_plot_frames(variant, utility_codes)
+        if zoom_to_feasible_range
+        else _ordered_plot_frames(variant, utility_codes)
+    )
     # Add season column so the vline appears in the shared color + linetype legend
     vline_df = vline_df.with_columns(pl.lit(_LEGEND_CURRENT).alias("season"))
 
@@ -543,6 +706,221 @@ def plot_feasible_fixed_charge_ranges(variant: str, title: str):
     )
     fig = p.draw()
     display_svg(fig)
+
+
+def _revenue_sufficient_plot_frames(
+    variant: str,
+    utility_codes: list[str],
+) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+    variant_key = "delivery" if variant == "Delivery only" else "supply"
+    utility_labels = [UTIL_NAMES[utility] for utility in utility_codes]
+    utility_dtype = pl.Enum(utility_labels)
+    season_dtype = pl.Enum(["Winter", "Summer"])
+    rate_rows = []
+    cross_subsidy_rows = []
+    endpoint_rows = []
+
+    for utility in utility_codes:
+        data = revenue_sufficient_lines[utility][variant_key]
+        winter_rates = _linspace(data.winter_rate_min, data.winter_rate_max, n=120)
+        for winter_rate in winter_rates:
+            summer_rate = data.summer_rate_at(winter_rate)
+            context = {
+                "utility": utility,
+                "utility_label": UTIL_NAMES[utility],
+                "variant": variant,
+                "winter_rate_cents_per_kwh": _rate_cents_per_kwh(winter_rate),
+            }
+            rate_rows.extend(
+                [
+                    {
+                        **context,
+                        "rate_cents_per_kwh": _rate_cents_per_kwh(winter_rate),
+                        "season": "Winter",
+                    },
+                    {
+                        **context,
+                        "rate_cents_per_kwh": _rate_cents_per_kwh(summer_rate),
+                        "season": "Summer",
+                    },
+                ]
+            )
+            cross_subsidy_rows.append(
+                {
+                    **context,
+                    "cross_subsidy_per_customer": data.subclass_cross_subsidy_per_customer_at(winter_rate),
+                }
+            )
+
+        floor_cross_subsidy = data.subclass_cross_subsidy_per_customer_at(data.winter_rate_min)
+        endpoint_rows.append(
+            {
+                "utility": utility,
+                "utility_label": UTIL_NAMES[utility],
+                "variant": variant,
+                "winter_rate_cents_per_kwh": _rate_cents_per_kwh(data.winter_rate_min),
+                "cross_subsidy_per_customer": floor_cross_subsidy,
+                "label": f"${floor_cross_subsidy:,.0f}/customer",
+            }
+        )
+
+    rate_df = (
+        pl.DataFrame(rate_rows)
+        .with_columns(
+            pl.col("utility_label").cast(utility_dtype),
+            pl.col("season").cast(season_dtype),
+        )
+        .sort("utility_label", "season", "winter_rate_cents_per_kwh")
+    )
+    cross_subsidy_df = (
+        pl.DataFrame(cross_subsidy_rows)
+        .with_columns(pl.col("utility_label").cast(utility_dtype))
+        .sort("utility_label", "winter_rate_cents_per_kwh")
+    )
+    endpoint_df = pl.DataFrame(endpoint_rows).with_columns(
+        pl.col("utility_label").cast(utility_dtype)
+    )
+    return rate_df, cross_subsidy_df, endpoint_df
+
+
+def plot_revenue_sufficient_rates(
+    variant: str,
+    utility_codes: list[str],
+    title: str,
+):
+    rate_df, _, _ = _revenue_sufficient_plot_frames(variant, utility_codes)
+    current_df = (
+        rate_df.filter(pl.col("season") == "Winter")
+        .sort("utility_label", "winter_rate_cents_per_kwh")
+        .group_by("utility_label", maintain_order=True)
+        .last()
+        .with_columns(pl.lit("Current").alias("label"))
+    )
+
+    p = (
+        ggplot(rate_df, aes("winter_rate_cents_per_kwh", "rate_cents_per_kwh", color="season", linetype="season"))
+        + geom_line(size=0.85)
+        + geom_point(
+            current_df,
+            aes("winter_rate_cents_per_kwh", "rate_cents_per_kwh"),
+            inherit_aes=False,
+            color=SB_COLORS["sky"],
+            size=3.0,
+        )
+        + geom_text(
+            current_df,
+            aes("winter_rate_cents_per_kwh", "rate_cents_per_kwh", label="label"),
+            inherit_aes=False,
+            color=SB_COLORS["sky"],
+            size=8,
+            ha="right",
+            va="bottom",
+            nudge_x=-0.25,
+            nudge_y=0.35,
+        )
+        + facet_wrap("utility_label", ncol=2, scales="free")
+        + scale_color_manual(
+            values={
+                "Winter": SB_COLORS["midnight"],
+                "Summer": SB_COLORS["carrot"],
+            }
+        )
+        + scale_linetype_manual(
+            values={
+                "Winter": "solid",
+                "Summer": "dashed",
+            }
+        )
+        + scale_x_continuous(
+            expand=(0, 0, 0.08, 0),
+            labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
+        )
+        + scale_y_continuous(
+            expand=(0, 0, 0.12, 0),
+            labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
+        )
+        + labs(
+            title=title,
+            subtitle="At the current fixed charge, winter rates are swept down from the current flat rate; summer rates rise to maintain revenue sufficiency. Cost-reflective MC seasonal marker is an outstanding follow-up.",
+            x="Winter volumetric rate",
+            y="Volumetric rate",
+            color="",
+            linetype="",
+        )
+        + theme_switchbox()
+        + theme(figure_size=(12.5, 15.0), legend_position="bottom")
+    )
+    fig = p.draw()
+    display_svg(fig)
+
+
+def plot_revenue_sufficient_cross_subsidy(
+    variant: str,
+    utility_codes: list[str],
+    title: str,
+):
+    _, cross_subsidy_df, endpoint_df = _revenue_sufficient_plot_frames(variant, utility_codes)
+    y_min_raw = min(float(cross_subsidy_df["cross_subsidy_per_customer"].min()), 0.0)
+    y_max_raw = max(float(cross_subsidy_df["cross_subsidy_per_customer"].max()), 0.0)
+    y_span = max(y_max_raw - y_min_raw, 1.0)
+    y_limits = (y_min_raw - 0.08 * y_span, y_max_raw + 0.12 * y_span)
+    zero_line_df = (
+        cross_subsidy_df.group_by("utility_label", maintain_order=True)
+        .agg(
+            pl.col("winter_rate_cents_per_kwh").min().alias("xmin"),
+            pl.col("winter_rate_cents_per_kwh").max().alias("xmax"),
+        )
+        .with_columns(pl.lit(0.0).alias("y"))
+    )
+
+    p = (
+        ggplot(cross_subsidy_df, aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer"))
+        + geom_segment(
+            zero_line_df,
+            aes(x="xmin", xend="xmax", y="y", yend="y"),
+            inherit_aes=False,
+            color="#6F6F6F",
+            linetype="dotted",
+            size=0.65,
+        )
+        + geom_line(size=0.9, color=SB_COLORS["midnight"])
+        + geom_point(
+            endpoint_df,
+            aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer"),
+            inherit_aes=False,
+            color=SB_COLORS["carrot"],
+            size=2.3,
+        )
+        + geom_text(
+            endpoint_df,
+            aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer", label="label"),
+            inherit_aes=False,
+            color=SB_COLORS["carrot"],
+            size=8,
+            ha="left",
+            va="center",
+            nudge_x=0.25,
+        )
+        + facet_wrap("utility_label", ncol=2, scales="free_x")
+        + scale_x_continuous(
+            expand=(0, 0, 0.08, 0),
+            labels=lambda breaks: [f"{b:,.1f}¢/kWh" for b in breaks],
+        )
+        + scale_y_continuous(
+            limits=y_limits,
+            labels=lambda breaks: [f"${b:,.0f}" for b in breaks],
+        )
+        + labs(
+            title=title,
+            subtitle="Positive values mean heat-pump customers are overpaying relative to their BAT benchmark. Dotted lines mark zero; orange points mark the residual at a zero winter rate.",
+            x="Winter volumetric rate",
+            y="Cross-subsidy per heat-pump customer",
+        )
+        + theme_switchbox()
+        + theme(figure_size=(12.5, 13.5), legend_position="none")
+    )
+    fig = p.draw()
+    display_svg(fig)
 ```
 
 ## Feasible Seasonal Rates
@@ -569,6 +947,32 @@ plot_multi_utility_feasible_grid(
 )
 ```
 
+## Zoomed Feasible Seasonal Rates
+
+```{python}
+#| label: fig-feasible-lines-delivery-zoomed
+#| fig-cap: "Zoomed feasible fixed-charge and seasonal delivery-rate combinations for each New York utility."
+
+plot_multi_utility_feasible_grid(
+    "Delivery only",
+    UTIL_ORDER_CODES,
+    "Zoomed feasible fair-default delivery rates by utility",
+    zoom_to_feasible_range=True,
+)
+```
+
+```{python}
+#| label: fig-feasible-lines-delivery-supply-zoomed
+#| fig-cap: "Zoomed feasible fixed-charge and seasonal delivery-plus-supply rate combinations for each New York utility."
+
+plot_multi_utility_feasible_grid(
+    "Delivery + supply",
+    UTIL_ORDER_CODES,
+    "Zoomed feasible fair-default delivery-plus-supply rates by utility",
+    zoom_to_feasible_range=True,
+)
+```
+
 ## Feasible Fixed-Charge Ranges
 
 ```{python}
@@ -583,4 +987,35 @@ plot_feasible_fixed_charge_ranges("Delivery only", "Feasible default delivery fi
 #| fig-cap: "Feasible default fixed-charge ranges by utility for delivery-plus-supply rates."
 
 plot_feasible_fixed_charge_ranges("Delivery + supply", "Feasible default delivery-plus-supply fixed-charge ranges")
+```
+
+## Revenue-Sufficient Seasonal Sweep
+
+The feasible-line plots above solve for rate combinations that satisfy both revenue sufficiency and full cross-subsidy elimination.
+Here, we look at a narrower lever: keep the current fixed charge, lower the winter delivery rate, and raise the summer delivery rate just enough to keep the utility revenue-sufficient.
+This does **not** require the heat-pump cross-subsidy to reach zero.
+
+The cost-reflective seasonal marker is intentionally left out for now.
+Adding it requires carrying the marginal-cost seasonal ratio into this notebook or persisting it with the run outputs.
+
+```{python}
+#| label: fig-rev-sufficient-rates
+#| fig-cap: "Revenue-sufficient delivery-rate pairs as the winter rate is lowered from the current default rate."
+
+plot_revenue_sufficient_rates(
+    "Delivery only",
+    UTIL_ORDER_CODES,
+    "Revenue-sufficient seasonal delivery rates by utility",
+)
+```
+
+```{python}
+#| label: fig-rev-sufficient-cross-subsidy
+#| fig-cap: "Residual heat-pump cross-subsidy under revenue-sufficient seasonal delivery rates."
+
+plot_revenue_sufficient_cross_subsidy(
+    "Delivery only",
+    UTIL_ORDER_CODES,
+    "Cross-subsidy remaining after revenue-sufficient seasonal differentiation",
+)
 ```

--- a/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
+++ b/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
@@ -709,6 +709,37 @@ def plot_feasible_fixed_charge_ranges(variant: str, title: str):
     display_svg(fig)
 
 
+_FIXED_CHARGE_LEVELS = [
+    "Current fixed charge",
+    "Fixed charge step 2",
+    "Fixed charge step 3",
+    "Minimum feasible fixed charge",
+]
+_FIXED_CHARGE_COLORS = {
+    "Current fixed charge": SB_COLORS["sky"],
+    "Fixed charge step 2": SB_COLORS["midnight"],
+    "Fixed charge step 3": SB_COLORS["carrot"],
+    "Minimum feasible fixed charge": SB_COLORS["pistachio"],
+}
+
+
+def _revenue_sufficient_fixed_charge_specs(data: RevenueSufficientLineData) -> list[dict[str, object]]:
+    base = data.base_fixed_charge
+    min_feasible = data.feasible_min_fixed_charge
+    if not data.feasible_min_exists or not math.isfinite(min_feasible) or min_feasible <= base:
+        min_feasible = base * 4.0
+    fixed_charges = _linspace(base, min_feasible, n=4)
+    return [
+        {
+            "fixed_charge_level": level,
+            "fixed_charge_label": f"${fixed_charge:,.0f}/mo"
+            + (" (min feasible)" if level == "Minimum feasible fixed charge" else ""),
+            "fixed_charge": fixed_charge,
+        }
+        for level, fixed_charge in zip(_FIXED_CHARGE_LEVELS, fixed_charges, strict=True)
+    ]
+
+
 def _revenue_sufficient_plot_frames(
     variant: str,
     utility_codes: list[str],
@@ -717,69 +748,99 @@ def _revenue_sufficient_plot_frames(
     utility_labels = [UTIL_NAMES[utility] for utility in utility_codes]
     utility_dtype = pl.Enum(utility_labels)
     season_dtype = pl.Enum(["Winter", "Summer"])
+    fixed_charge_level_dtype = pl.Enum(_FIXED_CHARGE_LEVELS)
     rate_rows = []
     cross_subsidy_rows = []
     endpoint_rows = []
 
     for utility in utility_codes:
         data = revenue_sufficient_lines[utility][variant_key]
-        winter_rates = _linspace(data.winter_rate_min, data.winter_rate_max, n=120)
-        for winter_rate in winter_rates:
-            summer_rate = data.summer_rate_at(winter_rate)
-            context = {
-                "utility": utility,
-                "utility_label": UTIL_NAMES[utility],
-                "variant": variant,
-                "winter_rate_cents_per_kwh": _rate_cents_per_kwh(winter_rate),
-            }
-            rate_rows.extend(
-                [
+        fixed_charge_specs = _revenue_sufficient_fixed_charge_specs(data)
+        winter_rate_max = max(
+            data.flat_rate_at(float(spec["fixed_charge"])) for spec in fixed_charge_specs
+        )
+        winter_rates = _linspace(data.winter_rate_min, max(data.winter_rate_min, winter_rate_max), n=120)
+        for spec in fixed_charge_specs:
+            fixed_charge = float(spec["fixed_charge"])
+            flat_rate_at_fixed_charge = data.flat_rate_at(fixed_charge)
+            for winter_rate in winter_rates:
+                if winter_rate > flat_rate_at_fixed_charge:
+                    continue
+                summer_rate = data.summer_rate_at(
+                    winter_rate=winter_rate,
+                    fixed_charge=fixed_charge,
+                )
+                context = {
+                    "utility": utility,
+                    "utility_label": UTIL_NAMES[utility],
+                    "variant": variant,
+                    "winter_rate_cents_per_kwh": _rate_cents_per_kwh(winter_rate),
+                    **spec,
+                }
+                rate_rows.extend(
+                    [
+                        {
+                            **context,
+                            "rate_cents_per_kwh": _rate_cents_per_kwh(winter_rate),
+                            "season": "Winter",
+                        },
+                        {
+                            **context,
+                            "rate_cents_per_kwh": _rate_cents_per_kwh(summer_rate),
+                            "season": "Summer",
+                        },
+                    ]
+                )
+                cross_subsidy_rows.append(
                     {
                         **context,
-                        "rate_cents_per_kwh": _rate_cents_per_kwh(winter_rate),
-                        "season": "Winter",
-                    },
-                    {
-                        **context,
-                        "rate_cents_per_kwh": _rate_cents_per_kwh(summer_rate),
-                        "season": "Summer",
-                    },
-                ]
+                        "cross_subsidy_per_customer": data.subclass_cross_subsidy_per_customer_at(
+                            winter_rate=winter_rate,
+                            fixed_charge=fixed_charge,
+                        ),
+                    }
+                )
+
+            floor_cross_subsidy = data.subclass_cross_subsidy_per_customer_at(
+                winter_rate=data.winter_rate_min,
+                fixed_charge=fixed_charge,
             )
-            cross_subsidy_rows.append(
+            endpoint_rows.append(
                 {
-                    **context,
-                    "cross_subsidy_per_customer": data.subclass_cross_subsidy_per_customer_at(winter_rate),
+                    "utility": utility,
+                    "utility_label": UTIL_NAMES[utility],
+                    "variant": variant,
+                    "winter_rate_cents_per_kwh": _rate_cents_per_kwh(data.winter_rate_min),
+                    **spec,
+                    "cross_subsidy_per_customer": floor_cross_subsidy,
+                    "label": f'{spec["fixed_charge_label"]}: ${floor_cross_subsidy:,.0f}/customer',
                 }
             )
-
-        floor_cross_subsidy = data.subclass_cross_subsidy_per_customer_at(data.winter_rate_min)
-        endpoint_rows.append(
-            {
-                "utility": utility,
-                "utility_label": UTIL_NAMES[utility],
-                "variant": variant,
-                "winter_rate_cents_per_kwh": _rate_cents_per_kwh(data.winter_rate_min),
-                "cross_subsidy_per_customer": floor_cross_subsidy,
-                "label": f"${floor_cross_subsidy:,.0f}/customer",
-            }
-        )
 
     rate_df = (
         pl.DataFrame(rate_rows)
         .with_columns(
             pl.col("utility_label").cast(utility_dtype),
             pl.col("season").cast(season_dtype),
+            pl.col("fixed_charge_level").cast(fixed_charge_level_dtype),
         )
-        .sort("utility_label", "season", "winter_rate_cents_per_kwh")
+        .sort("utility_label", "fixed_charge_level", "season", "winter_rate_cents_per_kwh")
     )
     cross_subsidy_df = (
         pl.DataFrame(cross_subsidy_rows)
-        .with_columns(pl.col("utility_label").cast(utility_dtype))
-        .sort("utility_label", "winter_rate_cents_per_kwh")
+        .with_columns(
+            pl.col("utility_label").cast(utility_dtype),
+            pl.col("fixed_charge_level").cast(fixed_charge_level_dtype),
+        )
+        .sort("utility_label", "fixed_charge_level", "winter_rate_cents_per_kwh")
     )
-    endpoint_df = pl.DataFrame(endpoint_rows).with_columns(
-        pl.col("utility_label").cast(utility_dtype)
+    endpoint_df = (
+        pl.DataFrame(endpoint_rows)
+        .with_columns(
+            pl.col("utility_label").cast(utility_dtype),
+            pl.col("fixed_charge_level").cast(fixed_charge_level_dtype),
+        )
+        .sort("utility_label", "fixed_charge_level")
     )
     return rate_df, cross_subsidy_df, endpoint_df
 
@@ -790,6 +851,7 @@ def plot_revenue_sufficient_rates(
     title: str,
 ):
     rate_df, _, _ = _revenue_sufficient_plot_frames(variant, utility_codes)
+    rate_df = rate_df.filter(pl.col("fixed_charge_level") == "Current fixed charge")
     current_df = (
         rate_df.filter(pl.col("season") == "Winter")
         .sort("utility_label", "winter_rate_cents_per_kwh")
@@ -871,7 +933,14 @@ def plot_revenue_sufficient_cross_subsidy(
     )
 
     p = (
-        ggplot(cross_subsidy_df, aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer"))
+        ggplot(
+            cross_subsidy_df,
+            aes(
+                "winter_rate_cents_per_kwh",
+                "cross_subsidy_per_customer",
+                color="fixed_charge_level",
+            ),
+        )
         + geom_segment(
             zero_line_df,
             aes(x="xmin", xend="xmax", y="y", yend="y"),
@@ -880,19 +949,22 @@ def plot_revenue_sufficient_cross_subsidy(
             linetype="dotted",
             size=0.65,
         )
-        + geom_line(size=0.9, color=SB_COLORS["midnight"])
+        + geom_line(size=0.9)
         + geom_point(
             endpoint_df,
-            aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer"),
+            aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer", color="fixed_charge_level"),
             inherit_aes=False,
-            color=SB_COLORS["carrot"],
             size=2.3,
         )
         + geom_label(
             endpoint_df,
-            aes("winter_rate_cents_per_kwh", "cross_subsidy_per_customer", label="label"),
+            aes(
+                "winter_rate_cents_per_kwh",
+                "cross_subsidy_per_customer",
+                label="label",
+                color="fixed_charge_level",
+            ),
             inherit_aes=False,
-            color=SB_COLORS["carrot"],
             fill="white",
             label_size=0.25,
             label_padding=0.12,
@@ -910,14 +982,16 @@ def plot_revenue_sufficient_cross_subsidy(
             expand=(0.08, 0, 0.16, 0),
             labels=lambda breaks: [f"${b:,.0f}" for b in breaks],
         )
+        + scale_color_manual(values=_FIXED_CHARGE_COLORS)
         + labs(
             title=title,
-            subtitle="Positive values mean heat-pump customers are overpaying relative to their BAT benchmark. Dotted lines mark zero; orange points mark the residual at a zero winter rate.",
+            subtitle="Positive values mean heat-pump customers are overpaying relative to their BAT benchmark. Dotted lines mark zero; endpoint labels show the residual at a zero winter rate.",
             x="Winter volumetric rate",
             y="Cross-subsidy per heat-pump customer",
+            color="Fixed charge",
         )
         + theme_switchbox()
-        + theme(figure_size=(12.5, 13.5), legend_position="none")
+        + theme(figure_size=(12.5, 13.5), legend_position="bottom")
     )
     fig = p.draw()
     display_svg(fig)

--- a/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
+++ b/reports/ny_hp_rates/notebooks/fair_default_feasible_line.qmd
@@ -251,7 +251,6 @@ def _verify_affine_vs_strategies(data: FeasibleLineData) -> None:
 
 
 def _sweep_range(data: FeasibleLineData, f_min: float | None = None, f_max: float | None = None) -> tuple[float, float]:
-    fc_floor = max(0.0, data.fixed_charge_floor)
     r_sum_zero = data.r_sum.zero_crossing()
     r_win_zero = data.r_win.zero_crossing()
     natural_upper = max(
@@ -262,7 +261,7 @@ def _sweep_range(data: FeasibleLineData, f_min: float | None = None, f_max: floa
     for sp in data.strategies:
         if math.isfinite(sp.fixed_charge):
             natural_upper = max(natural_upper, sp.fixed_charge)
-    lo = f_min if f_min is not None else max(20.0, fc_floor)
+    lo = f_min if f_min is not None else 0.0
     hi = f_max if f_max is not None else natural_upper + 10.0
     if hi <= lo:
         hi = lo + 20.0
@@ -284,7 +283,7 @@ def _strategy_rate(data: FeasibleLineData, strategy: StrategyPoint, line: Affine
     return _rate_cents_per_kwh(line.at(strategy.fixed_charge))
 
 
-def _plot_frames(data: FeasibleLineData) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+def _plot_frames(data: FeasibleLineData) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, tuple[float, float]]:
     lo, hi = _sweep_range(data)
     fs = _linspace(lo, hi)
     line_rows = []
@@ -324,6 +323,8 @@ def _plot_frames(data: FeasibleLineData) -> tuple[pl.DataFrame, pl.DataFrame, pl
     y_min = min(float(line_df["rate_cents_per_kwh"].min()), 0.0)
     y_max = max(float(line_df["rate_cents_per_kwh"].max()), 0.0)
     y_pad = max((y_max - y_min) * 0.08, 0.5)
+    y_lo = y_min - y_pad
+    y_hi = y_max + y_pad
     feas_lo = max(data.feasible_min if math.isfinite(data.feasible_min) else lo, lo)
     feas_hi = min(data.feasible_max if math.isfinite(data.feasible_max) else hi, hi)
     rect_df = pl.DataFrame(
@@ -331,25 +332,26 @@ def _plot_frames(data: FeasibleLineData) -> tuple[pl.DataFrame, pl.DataFrame, pl
             {
                 "xmin": feas_lo,
                 "xmax": feas_hi,
-                "ymin": y_min - y_pad,
-                "ymax": y_max + y_pad,
+                "ymin": y_lo,
+                "ymax": y_hi,
             }
         ]
         if data.feasible_exists and feas_hi > feas_lo
         else []
     )
-    return line_df, strategy_df, rect_df
+    return line_df, strategy_df, rect_df, (y_lo, y_hi)
 
 
-def _all_plot_frames() -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.DataFrame]:
+def _all_plot_frames() -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.DataFrame]:
     line_frames = []
     strategy_frames = []
     rect_frames = []
     range_rows = []
+    vline_frames = []
     for utility in UTIL_ORDER_CODES:
         for variant, data in feasible_lines[utility].items():
             _verify_affine_vs_strategies(data)
-            line_df, strategy_df, rect_df = _plot_frames(data)
+            line_df, strategy_df, rect_df, (y_lo, y_hi) = _plot_frames(data)
             variant_label = "Delivery only" if variant == "delivery" else "Delivery + supply"
             context = {
                 "utility": utility,
@@ -368,22 +370,36 @@ def _all_plot_frames() -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame, pl.Dat
                     "feasible_exists": data.feasible_exists,
                 }
             )
+            # Vline row: use concrete y_lo/y_hi so plotnine never sees ±inf
+            if math.isfinite(data.base_fixed_charge):
+                vline_frames.append(
+                    pl.DataFrame(
+                        [{
+                            **context,
+                            "xintercept": data.base_fixed_charge,
+                            "label": f"${data.base_fixed_charge:,.0f}/mo",
+                            "y_lo": y_lo,
+                            "y_hi": y_hi,
+                        }]
+                    )
+                )
 
     return (
         pl.concat(line_frames),
         pl.concat(strategy_frames),
         pl.concat(rect_frames) if rect_frames else pl.DataFrame(),
         pl.DataFrame(range_rows),
+        pl.concat(vline_frames) if vline_frames else pl.DataFrame(),
     )
 
 
-line_all, strategy_all, rect_all, range_all = _all_plot_frames()
+line_all, strategy_all, rect_all, range_all, vline_all = _all_plot_frames()
 
 
 def _ordered_plot_frames(
     variant: str,
     utility_codes: list[str],
-) -> tuple[pl.DataFrame, pl.DataFrame]:
+) -> tuple[pl.DataFrame, pl.DataFrame, pl.DataFrame]:
     utility_labels = [UTIL_NAMES[utility] for utility in utility_codes]
     utility_dtype = pl.Enum(utility_labels)
     season_dtype = pl.Enum(["Winter", "Summer"])
@@ -404,11 +420,24 @@ def _ordered_plot_frames(
         )
         .with_columns(pl.col("utility_label").cast(utility_dtype))
     )
-    return line_df, rect_df
+    vline_df = (
+        vline_all.filter(
+            (pl.col("variant") == variant)
+            & (pl.col("utility").is_in(utility_codes))
+        )
+        .with_columns(pl.col("utility_label").cast(utility_dtype))
+    )
+    return line_df, rect_df, vline_df
+
+
+_LEGEND_CURRENT = "Current rate"
 
 
 def plot_multi_utility_feasible_grid(variant: str, utility_codes: list[str], title: str):
-    line_df, rect_df = _ordered_plot_frames(variant, utility_codes)
+    line_df, rect_df, vline_df = _ordered_plot_frames(variant, utility_codes)
+    # Add season column so the vline appears in the shared color + linetype legend
+    vline_df = vline_df.with_columns(pl.lit(_LEGEND_CURRENT).alias("season"))
+
     p = (
         ggplot(line_df, aes("fixed_charge", "rate_cents_per_kwh", color="season", linetype="season"))
         + geom_rect(
@@ -419,10 +448,39 @@ def plot_multi_utility_feasible_grid(variant: str, utility_codes: list[str], tit
             alpha=0.13,
             color="none",
         )
+        # Dotted vline with concrete y_lo/y_hi — no ±inf
+        + geom_segment(
+            vline_df,
+            aes(x="xintercept", xend="xintercept", y="y_lo", yend="y_hi", color="season", linetype="season"),
+            size=0.85,
+        )
+        # Dollar label near the top of each panel, nudged right of the vline
+        + geom_text(
+            vline_df,
+            aes(x="xintercept", y="y_hi", label="label"),
+            inherit_aes=False,
+            color=SB_COLORS["sky"],
+            size=8,
+            va="top",
+            ha="left",
+            nudge_x=1.5,
+        )
         + geom_line(size=0.85)
         + facet_wrap("utility_label", ncol=2, scales="free")
-        + scale_color_manual(values={"Winter": SB_COLORS["midnight"], "Summer": SB_COLORS["carrot"]})
-        + scale_linetype_manual(values={"Winter": "solid", "Summer": "dashed"})
+        + scale_color_manual(
+            values={
+                "Winter": SB_COLORS["midnight"],
+                "Summer": SB_COLORS["carrot"],
+                _LEGEND_CURRENT: SB_COLORS["sky"],
+            }
+        )
+        + scale_linetype_manual(
+            values={
+                "Winter": "solid",
+                "Summer": "dashed",
+                _LEGEND_CURRENT: "dotted",
+            }
+        )
         + scale_x_continuous(labels=lambda breaks: [f"${b:,.0f}" for b in breaks])
         + scale_y_continuous(labels=lambda breaks: [f"{b:,.2f}¢/kWh" for b in breaks])
         + labs(
@@ -430,8 +488,8 @@ def plot_multi_utility_feasible_grid(variant: str, utility_codes: list[str], tit
             subtitle="Each line shows the seasonal volumetric rate implied by a fixed-charge choice; the green band marks the feasible fixed-charge range.",
             x="Fixed charge",
             y="Volumetric rate",
-            color="Season",
-            linetype="Season",
+            color="",
+            linetype="",
         )
         + theme_switchbox()
         + theme(figure_size=(12.5, 13.5), legend_position="bottom")
@@ -442,27 +500,41 @@ def plot_multi_utility_feasible_grid(variant: str, utility_codes: list[str], tit
 
 def plot_feasible_fixed_charge_ranges(variant: str, title: str):
     ranges = range_all.filter((pl.col("feasible_exists")) & (pl.col("variant") == variant))
+    # Order utilities by feasible_min ascending (lowest required fixed charge first)
+    ordered_labels = (
+        ranges.sort("feasible_min")
+        .get_column("utility_label")
+        .to_list()
+    )
+    ranges = ranges.with_columns(
+        pl.col("utility_label").cast(pl.Enum(ordered_labels))
+    )
+    bar_color = SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"]
+    y_max = float(ranges["feasible_max"].max())
     p = (
         ggplot(ranges, aes("utility_label", "feasible_min"))
         + geom_segment(
             aes(x="utility_label", xend="utility_label", y="feasible_min", yend="feasible_max"),
             size=2.2,
             lineend="round",
-            color=SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"],
+            color=bar_color,
         )
         + geom_point(
             size=2.7,
-            color=SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"],
+            color=bar_color,
         )
         + geom_point(
             aes(y="feasible_max"),
             size=2.7,
-            color=SB_COLORS["midnight"] if variant == "Delivery only" else SB_COLORS["carrot"],
+            color=bar_color,
         )
-        + scale_y_continuous(labels=lambda breaks: [f"${b:,.0f}" for b in breaks])
+        + scale_y_continuous(
+            limits=(0, y_max * 1.08),
+            labels=lambda breaks: [f"${b:,.0f}" for b in breaks],
+        )
         + labs(
             title=title,
-            subtitle="Vertical ranges show the fixed charges for which both winter and summer volumetric rates are non-negative.",
+            subtitle="Vertical ranges show the fixed charges for which both winter and summer volumetric rates are non-negative. Utilities ordered by minimum feasible fixed charge.",
             x="Utility",
             y="Fixed charge",
         )

--- a/reports/ny_hp_rates/notebooks/find_new_representative_home.py
+++ b/reports/ny_hp_rates/notebooks/find_new_representative_home.py
@@ -1,0 +1,345 @@
+"""Find a new representative home for the NY HP Rates one-pager.
+
+Criteria from the user (one-pager messaging):
+
+1. Overpays for delivery (under default rate after switching to HP) by ~$855
+   (matches the headline statewide-average overpayment).
+2. Total energy bills go up after switching to HP under default rates.
+3. NG-heated home's delivery bill is BELOW its delivery cost of service
+   (gas BAT < 0 — gas-heated home underpays for delivery).
+4. HP customer on the dedicated HP rate has a delivery bill at or
+   slightly above their delivery cost of service (HP-rate BAT >= 0, small).
+5. Sizable increase in electricity costs (Syracuse home is ~2x kWh and bill).
+
+Plus the existing constraints from analysis.qmd:
+
+- Natural gas only (no oil/propane).
+- Building must have no LMI credit applied (so energy_total = sum of components,
+  matching the prose narrative).
+
+Important: BAT for u02 (HP) and u02hprate (HP rate) scenarios uses the
+baseline (run 1+2) residual_share_delivery, not the scenario's own residual.
+This mirrors the workaround in analysis.qmd's cross-subsidy-example-data cell.
+The scenario's own residual is calibrated for an unrealistic universe in which
+the entire NY building stock has switched fuel/rate; for a "single customer
+switches" thought experiment we hold the per-utility residual at the gas
+baseline.
+
+Run: uv run python notebooks/find_new_representative_home.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import polars as pl
+
+# --- Paths (mirror analysis.qmd) ---
+STATE = "NY"
+BATCH = "ny_20260416a_r1-36"
+S3_BASE = "s3://data.sb/switchbox/cairo/outputs/hp_rates"
+_BILLS = f"{S3_BASE}/{STATE.lower()}/all_utilities/{BATCH}"
+
+PATH_BILLS_BASELINE = f"{_BILLS}/run_1+2/comb_bills_year_target/"
+PATH_BILLS_HP_DEFAULT = f"{_BILLS}/run_3+4/comb_bills_year_target/"
+PATH_BILLS_HP_HPRATE = f"{_BILLS}/run_7+8/comb_bills_year_target/"
+PATH_BAT_BASELINE = f"{_BILLS}/run_1+2/cross_subsidization_BAT_values/"
+PATH_BAT_HP_DEFAULT = f"{_BILLS}/run_3+4/cross_subsidization_BAT_values/"
+PATH_BAT_HP_HPRATE = f"{_BILLS}/run_7+8/cross_subsidization_BAT_values/"
+
+ANNUAL_MONTH = "Annual"
+TARGET_BAT = 855.0
+RESSTOCK_META = "/ebs/data/nrel/resstock/res_2024_amy2018_2_sb/metadata/state=NY/upgrade=00/metadata-sb.parquet"
+
+SYRACUSE_BLDG_ID = 328510
+
+
+def _annual_bills(path: str, alias_prefix: str) -> pl.LazyFrame:
+    return (
+        pl.scan_parquet(path, hive_partitioning=True)
+        .filter(pl.col("month") == ANNUAL_MONTH)
+        .select(
+            "bldg_id",
+            "weight",
+            "sb.electric_utility",
+            "heats_with_natgas",
+            "heats_with_oil",
+            "heats_with_propane",
+            "in.hvac_cooling_partial_space_conditioning",
+            pl.col("elec_supply_bill").alias(f"{alias_prefix}_supply"),
+            pl.col("elec_delivery_bill").alias(f"{alias_prefix}_delivery_vol"),
+            pl.col("elec_fixed_charge").alias(f"{alias_prefix}_delivery_fixed"),
+            pl.col("gas_total_bill").alias(f"{alias_prefix}_gas"),
+            pl.col("oil_total_bill").alias(f"{alias_prefix}_oil"),
+            pl.col("propane_total_bill").alias(f"{alias_prefix}_propane"),
+            pl.col("elec_total_bill").alias(f"{alias_prefix}_elec_total"),
+            pl.col("elec_total_bill_lmi_40").alias(f"{alias_prefix}_elec_total_lmi40"),
+        )
+        .with_columns(
+            (
+                pl.col(f"{alias_prefix}_supply")
+                + pl.col(f"{alias_prefix}_delivery_vol")
+                + pl.col(f"{alias_prefix}_delivery_fixed")
+                + pl.col(f"{alias_prefix}_gas")
+                + pl.col(f"{alias_prefix}_oil")
+                + pl.col(f"{alias_prefix}_propane")
+            ).alias(f"{alias_prefix}_energy_total"),
+        )
+    )
+
+
+def _annual_bat(path: str, alias_prefix: str) -> pl.LazyFrame:
+    return pl.scan_parquet(path, hive_partitioning=True).select(
+        "bldg_id",
+        pl.col("annual_bill_delivery").alias(f"{alias_prefix}_bill_delivery"),
+        pl.col("economic_burden_delivery").alias(f"{alias_prefix}_mc_delivery"),
+        pl.col("residual_share_delivery").alias(f"{alias_prefix}_residual_delivery"),
+    )
+
+
+def main() -> int:
+    print("Loading bills + BAT for runs 1+2, 3+4, 7+8…", file=sys.stderr)
+
+    bills_baseline = _annual_bills(PATH_BILLS_BASELINE, "u00")
+    bills_hp = _annual_bills(PATH_BILLS_HP_DEFAULT, "u02")
+    bills_hp_hprate = _annual_bills(PATH_BILLS_HP_HPRATE, "u02hprate")
+    bat_baseline = _annual_bat(PATH_BAT_BASELINE, "u00")
+    bat_hp = _annual_bat(PATH_BAT_HP_DEFAULT, "u02")
+    bat_hp_hprate = _annual_bat(PATH_BAT_HP_HPRATE, "u02hprate")
+
+    drop_dup_cols = [
+        "weight",
+        "sb.electric_utility",
+        "heats_with_natgas",
+        "heats_with_oil",
+        "heats_with_propane",
+        "in.hvac_cooling_partial_space_conditioning",
+    ]
+    bills_hp = bills_hp.drop(drop_dup_cols)
+    bills_hp_hprate = bills_hp_hprate.drop(drop_dup_cols)
+
+    joined = (
+        bills_baseline.filter(pl.col("heats_with_natgas"))
+        .join(bills_hp, on="bldg_id", how="inner")
+        .join(bills_hp_hprate, on="bldg_id", how="inner")
+        .join(bat_baseline, on="bldg_id", how="left")
+        .join(bat_hp, on="bldg_id", how="left")
+        .join(bat_hp_hprate, on="bldg_id", how="left")
+    )
+
+    base = joined.filter(
+        (pl.col("u00_propane") == 0)
+        & (pl.col("u00_oil") == 0)
+        & (pl.col("u02_propane") == 0)
+        & (pl.col("u02_oil") == 0)
+    ).filter((pl.col("u00_elec_total") - pl.col("u00_elec_total_lmi40")).abs() < 1.0)
+
+    # BAT computation:
+    #   For u00 (gas baseline): use the run's own residual (no fix needed).
+    #   For u02 (HP, default rates): mc + bill from u02; residual from u00.
+    #   For u02hprate (HP, HP rate): mc + bill from u02hprate; residual from u00.
+    base = base.with_columns(
+        (pl.col("u00_bill_delivery") - pl.col("u00_mc_delivery") - pl.col("u00_residual_delivery")).alias("u00_bat"),
+        (pl.col("u02_bill_delivery") - pl.col("u02_mc_delivery") - pl.col("u00_residual_delivery")).alias("u02_bat"),
+        (pl.col("u02hprate_bill_delivery") - pl.col("u02hprate_mc_delivery") - pl.col("u00_residual_delivery")).alias(
+            "u02hprate_bat"
+        ),
+        (pl.col("u00_mc_delivery") + pl.col("u00_residual_delivery")).alias("u00_cos"),
+        (pl.col("u02_mc_delivery") + pl.col("u00_residual_delivery")).alias("u02_cos"),
+        (pl.col("u02hprate_mc_delivery") + pl.col("u00_residual_delivery")).alias("u02hprate_cos"),
+        (pl.col("u02_supply") / pl.col("u00_supply")).alias("supply_multiplier"),
+        (
+            (pl.col("u02_delivery_vol") + pl.col("u02_delivery_fixed"))
+            / (pl.col("u00_delivery_vol") + pl.col("u00_delivery_fixed"))
+        ).alias("delivery_multiplier"),
+        (pl.col("u02_elec_total") / pl.col("u00_elec_total")).alias("elec_total_multiplier"),
+        (pl.col("u02_energy_total") - pl.col("u00_energy_total")).alias("net_increase"),
+        (pl.col("u02_gas") - pl.col("u00_gas")).alias("gas_bill_change"),
+    ).with_columns(
+        (pl.col("u02_bat") - TARGET_BAT).abs().alias("bat_distance"),
+    )
+
+    base_df = base.collect()
+    print(f"\nBaseline natgas-only/no-LMI cohort: {base_df.height:,} buildings", file=sys.stderr)
+
+    # --- Diagnostic on the existing Syracuse home ---
+    print("\n=== Existing Syracuse home (bldg_id=328510) ===")
+    syr = base_df.filter(pl.col("bldg_id") == SYRACUSE_BLDG_ID)
+    if syr.is_empty():
+        print("Syracuse home not in cohort")
+    else:
+        r = syr.row(0, named=True)
+        for k in (
+            "sb.electric_utility",
+            "in.hvac_cooling_partial_space_conditioning",
+            "u00_energy_total",
+            "u02_energy_total",
+            "net_increase",
+            "u00_elec_total",
+            "u02_elec_total",
+            "elec_total_multiplier",
+            "supply_multiplier",
+            "delivery_multiplier",
+            "gas_bill_change",
+            "u00_bill_delivery",
+            "u00_cos",
+            "u00_bat",
+            "u02_bill_delivery",
+            "u02_cos",
+            "u02_bat",
+            "u02hprate_bill_delivery",
+            "u02hprate_cos",
+            "u02hprate_bat",
+        ):
+            v = r[k]
+            if isinstance(v, float):
+                print(f"  {k}: {v:,.2f}")
+            else:
+                print(f"  {k}: {v}")
+
+    # --- Distribution diagnostics ---
+    def _pcts(col: str, label: str) -> None:
+        print(f"\n{label} percentiles:")
+        for q in (0.05, 0.10, 0.25, 0.5, 0.75, 0.9, 0.95):
+            print(f"  p{int(q * 100)}: {base_df[col].quantile(q):,.0f}")
+
+    _pcts("u02_bat", f"u02_bat (target ${TARGET_BAT:.0f})")
+    _pcts("u02hprate_bat", "u02hprate_bat (target ~$0)")
+    _pcts("u00_bat", "u00_bat (gas, want negative)")
+    _pcts("net_increase", "net_increase (want positive)")
+    _pcts("elec_total_multiplier", "elec_total_multiplier (target ~2x)")
+
+    # Stepwise filtering counts
+    print("\n=== Stepwise filter counts ===")
+    f1 = base_df.filter(pl.col("net_increase") > 0)
+    print(f"after net_increase > 0:                     {f1.height:>7,}")
+    f2 = f1.filter(pl.col("u00_bat") < 0)
+    print(f"after u00_bat < 0 (gas underpays):          {f2.height:>7,}")
+    f3 = f2.filter((pl.col("u02hprate_bat") >= -25) & (pl.col("u02hprate_bat") <= 100))
+    print(f"after -25 <= u02hprate_bat <= 100:          {f3.height:>7,}")
+    f4 = f3.filter(pl.col("in.hvac_cooling_partial_space_conditioning") == "100% Conditioned")
+    print(f"after full cooling:                         {f4.height:>7,}")
+    f5 = f4.filter(pl.col("bat_distance") <= 25)
+    print(f"after |u02_bat - 855| <= 25:                {f5.height:>7,}")
+    f6 = f4.filter(pl.col("bat_distance") <= 50)
+    print(f"after |u02_bat - 855| <= 50:                {f6.height:>7,}")
+    f7 = f4.filter(pl.col("bat_distance") <= 100)
+    print(f"after |u02_bat - 855| <= 100:               {f7.height:>7,}")
+
+    candidates = f4.with_columns(
+        (pl.col("elec_total_multiplier") - 2.0).abs().alias("mult_distance"),
+    ).with_columns(
+        (pl.col("bat_distance") + 100 * pl.col("mult_distance")).alias("score"),
+    )
+
+    display_cols = [
+        "bldg_id",
+        "sb.electric_utility",
+        "u00_energy_total",
+        "u02_energy_total",
+        "net_increase",
+        "u00_elec_total",
+        "u02_elec_total",
+        "elec_total_multiplier",
+        "supply_multiplier",
+        "delivery_multiplier",
+        "gas_bill_change",
+        "u00_bill_delivery",
+        "u00_cos",
+        "u00_bat",
+        "u02_bill_delivery",
+        "u02_cos",
+        "u02_bat",
+        "u02hprate_bill_delivery",
+        "u02hprate_cos",
+        "u02hprate_bat",
+        "bat_distance",
+        "mult_distance",
+        "score",
+    ]
+    pl.Config.set_tbl_cols(-1)
+    pl.Config.set_tbl_rows(60)
+    pl.Config.set_tbl_width_chars(420)
+    pl.Config.set_fmt_float("mixed")
+
+    print(f"\n{'=' * 80}")
+    print(f"Top 25 by COMBINED score (bat distance + 100 * |mult-2|), within {f4.height} valid candidates")
+    print(f"{'=' * 80}\n")
+    by_score = candidates.sort("score").head(25)
+    print(by_score.select(display_cols))
+
+    print(f"\n{'=' * 80}")
+    print(f"Top 25 by BAT proximity to ${TARGET_BAT}")
+    print(f"{'=' * 80}\n")
+    by_bat = candidates.sort("bat_distance").head(25)
+    print(by_bat.select(display_cols))
+
+    # Pull metadata for top union and show.
+    top_ids = list(set(by_score["bldg_id"].head(15).to_list() + by_bat["bldg_id"].head(15).to_list()))
+    if not top_ids:
+        print("No candidates found. Exiting.")
+        return 0
+    print(f"\n{'=' * 80}")
+    print(f"Detailed metadata for top {len(top_ids)} (union of two ranking views):")
+    print(f"{'=' * 80}\n")
+
+    META_COLS = [
+        "bldg_id",
+        "in.county",
+        "in.geometry_floor_area",
+        "in.bedrooms",
+        "in.geometry_stories",
+        "in.geometry_building_type_acs",
+        "in.geometry_building_type_recs",
+        "in.tenure",
+        "in.vintage_acs",
+        "in.vintage",
+        "in.hvac_heating_efficiency",
+        "in.hvac_cooling_efficiency",
+        "in.hvac_cooling_partial_space_conditioning",
+        "in.insulation_wall",
+        "in.weather_file_city",
+    ]
+    meta = pl.scan_parquet(RESSTOCK_META).filter(pl.col("bldg_id").is_in(top_ids)).select(META_COLS).collect()
+
+    top_rows = candidates.filter(pl.col("bldg_id").is_in(top_ids)).sort("score").join(meta, on="bldg_id", how="left")
+
+    rows = top_rows.to_dicts()
+    for i, r in enumerate(rows, start=1):
+        print(f"--- Rank {i} (score={r['score']:.0f}): bldg_id={r['bldg_id']} | utility={r['sb.electric_utility']} ---")
+        print(f"  City / county      : {r.get('in.weather_file_city')!s:<35} {r.get('in.county')}")
+        print(
+            f"  Building type      : {r.get('in.geometry_building_type_acs')!s} ({r.get('in.geometry_building_type_recs')})"
+        )
+        print(
+            f"  Tenure / floor sqft: {r.get('in.tenure')!s:<10} {r.get('in.geometry_floor_area')!s} sqft, {r.get('in.bedrooms')} bed, {r.get('in.geometry_stories')} story"
+        )
+        print(f"  Vintage            : {r.get('in.vintage_acs')!s} ({r.get('in.vintage')})")
+        print(f"  Heating eff (AFUE) : {r.get('in.hvac_heating_efficiency')}")
+        print(
+            f"  Cooling eff/share  : {r.get('in.hvac_cooling_efficiency')!s} ({r.get('in.hvac_cooling_partial_space_conditioning')})"
+        )
+        print(f"  Wall insulation    : {r.get('in.insulation_wall')}")
+        print(
+            f"  Energy total       : ${r['u00_energy_total']:>7,.0f}  ->  ${r['u02_energy_total']:>7,.0f}  (delta: ${r['net_increase']:+,.0f})"
+        )
+        print(
+            f"  Electric total     : ${r['u00_elec_total']:>7,.0f}  ->  ${r['u02_elec_total']:>7,.0f}  (mult {r['elec_total_multiplier']:.2f}x; supply {r['supply_multiplier']:.2f}x; delivery {r['delivery_multiplier']:.2f}x)"
+        )
+        print(f"  Gas bill change    : ${r['gas_bill_change']:+,.0f}")
+        print(
+            f"  Delivery (NG dflt) : bill ${r['u00_bill_delivery']:>7,.0f}  COS ${r['u00_cos']:>7,.0f}  BAT ${r['u00_bat']:+,.0f}"
+        )
+        print(
+            f"  Delivery (HP dflt) : bill ${r['u02_bill_delivery']:>7,.0f}  COS ${r['u02_cos']:>7,.0f}  BAT ${r['u02_bat']:+,.0f}  (target ~$855)"
+        )
+        print(
+            f"  Delivery (HP rate) : bill ${r['u02hprate_bill_delivery']:>7,.0f}  COS ${r['u02hprate_cos']:>7,.0f}  BAT ${r['u02hprate_bat']:+,.0f}  (target ~$0)"
+        )
+        print()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds a new `ny_hp_rates` notebook for fair default feasible line analysis.
- Includes updated plots for fair-default comparisons and cross-subsidy lines.
- Adds the notebook to the `ny_hp_rates` Quarto render list.

## Reviewer Focus
Please focus on whether the fair-default framing and cross-subsidy line plots are clear enough for review, and whether the notebook belongs in the project render list at this stage.

## Non-Obvious Details
`main` was accidentally merged into directly first, then reverted without rewriting shared history. This branch has been rebuilt on top of the corrected `main` so the PR shows the intended two-file diff.

## Test Plan
- Not run; PR only wires in and adds the analysis notebook.