### PR TITLE
[ri_hp_rates] Add Excel workbooks for RIE 1-8 and RIE 1-9 discovery responses

### DIFF
--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_11_DIV_7_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_11_DIV_7_workbook.py
@@ -25,9 +25,11 @@ group-by/sum.
 from __future__ import annotations
 
 import argparse
+import pickle
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import polars as pl
 import yaml
@@ -51,6 +53,9 @@ REF_CUSTOMER_CHARGE = "inputs_revenue_requirement!$B$5"
 REF_CORE_DELIVERY = "inputs_revenue_requirement!$B$6"
 REF_ANNUAL_FIXED_PER_CUSTOMER = "inputs_revenue_requirement!$B$7"
 REF_DISPLAY_TOTAL = "inputs_revenue_requirement!$B$8"
+REF_SUM_WEIGHTED_EB = "inputs_revenue_requirement!$B$9"
+REF_TOTAL_RESIDUAL = "inputs_revenue_requirement!$B$10"
+REF_EPMC_RATE = "inputs_revenue_requirement!$B$11"
 REF_DEFAULT_VOL = "inputs_tariffs!$B$2"
 
 # Same constants as cost_of_service_by_subclass.qmd; if the testimony rebases
@@ -119,7 +124,12 @@ HT_V2_LABELS: dict[str, str] = {
 
 
 def load_master_bat() -> pl.DataFrame:
-    """Mirror ``load_master_bat`` in ``cost_of_service_by_subclass.qmd``."""
+    """Mirror ``load_master_bat`` in ``cost_of_service_by_subclass.qmd``.
+
+    Loads ``residual_share_epmc_delivery`` and ``BAT_epmc_delivery`` from the
+    parquet for runtime validation only — these columns are derived via formulas
+    in the workbook (EPMC allocation from ``economic_burden_delivery``).
+    """
     df = (
         pl.scan_parquet(PATH_MASTER_BAT_12, hive_partitioning=True)
         .filter(pl.col("sb.electric_utility") == UTILITY)
@@ -199,14 +209,12 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         ["", "", ""],
         ["Item", "Source", "Notes"],
         [
-            "Per-building BAT outputs",
+            "Per-building CAIRO outputs",
             s3_bat,
-            "CAIRO batch outputs (one row per RIE residential building) used as the per-building basis for all weighted aggregates.",
-        ],
-        [
-            "CAIRO batch",
-            BATCH,
-            "RIE test-year status-quo batch (run_1+2 = uniform default delivery + supply for all customers).",
+            (
+                "One row per residential building. "
+                "RIE test-year status-quo run (run_1+2 = uniform default delivery + supply for all customers)."
+            ),
         ],
         [
             "Revenue-requirement YAML",
@@ -216,23 +224,24 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         [
             "Calibrated default tariff JSON",
             _rdp_permalink(f"{RDP_TARIFF_DIR}/rie_default_calibrated.json"),
-            "energyratestructure[0][0].rate is the default uniform $/kWh used to back out annual kWh per building from delivery bill.",
+            "energyratestructure[0][0].rate is the default uniform $/kWh.",
         ],
         [
             "Notebook that produces the published table",
             _reports2_permalink("reports/ri_hp_rates/notebooks/cost_of_service_by_subclass.qmd"),
             "Cell tbl-cos-by-subclass-avg. This workbook reproduces its aggregation logic as live formulas.",
         ],
-        [
-            "Testimony embed",
-            _reports2_permalink("reports/ri_hp_rates/expert_testimony.qmd", line_range=(577, 579)),
-            "Quarto embed shortcode that pulls tbl-cos-by-subclass-avg into the testimony as Figure 15.",
-        ],
         ["", "", ""],
         ["Sheet", "What it contains", ""],
         [
             "inputs_revenue_requirement",
-            "Test-year customer count, total delivery revenue requirement, test-year residential kWh, customer charge total, core delivery rate total, derived annual fixed delivery $/customer.",
+            (
+                "Test-year customer count, total delivery revenue requirement, test-year residential kWh, "
+                "customer charge total, core delivery rate total, derived annual fixed delivery $/customer, "
+                "sum_weighted_eb (sum of weight * economic_burden_delivery), "
+                "total_residual (= total_RR - sum_weighted_eb), "
+                "and epmc_rate (= total_residual / sum_weighted_eb)."
+            ),
             "",
         ],
         [
@@ -243,10 +252,12 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         [
             "bat_per_building",
             (
-                "One row per RIE residential building. Columns from CAIRO BAT parquet, "
-                "annual_kwh back-derived from delivery bill (= (annual_bill_delivery - annual_fixed_per_customer) / vol_rate), "
-                "plus formula columns: cost_of_service_delivery, annual_bill_delivery_check (= annual_kwh * vol_rate + annual_fixed_per_customer), "
-                "and weighted aggregates. weight is uniform: test_year_customer_count / n_buildings (each building represents the same number of customers)."
+                "One row per residential building. Data columns: bldg_id, weight, heating_type_v2, "
+                "annual_bill_delivery, economic_burden_delivery (from CAIRO), and annual_kwh "
+                "(back-derived from delivery bill). Formula columns: "
+                "residual_share_epmc_delivery (= EB * epmc_rate), "
+                "BAT_epmc_delivery (= bill - COS), cost_of_service_delivery (= EB + residual_share), "
+                "and weighted_* products for aggregation."
             ),
             "",
         ],
@@ -258,11 +269,6 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         [
             "fig15_published",
             "Final published layout: customers, % of customers, average delivery bill, average cost of service, average cross-subsidy, and avg cross-subsidy / avg COS.",
-            "",
-        ],
-        [
-            "validation",
-            "Formula-level checks that mirror the polars asserts in the notebook (sum of weights, total revenue, cross-subsidy nets to zero, derived total kWh).",
             "",
         ],
         ["", "", ""],
@@ -280,29 +286,17 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         ],
         [
             "Avg. cost of service",
-            "SUMPRODUCT(weight, economic_burden_delivery + residual_share_epmc_delivery) / SUMIFS(weight, ...).",
+            "SUMPRODUCT(weight, cost_of_service_delivery) / SUMIFS(weight, ...). COS = EB * epmc_multiplier.",
             "",
         ],
         [
             "Avg. cross-subsidy",
-            "SUMPRODUCT(weight, BAT_epmc_delivery) / SUMIFS(weight, ...).",
+            "SUMPRODUCT(weight, BAT_epmc_delivery) / SUMIFS(weight, ...). BAT = bill - COS.",
             "",
         ],
         [
             "Avg. cross-subsidy / Avg. COS",
             "avg_cross_subsidy / avg_cost_of_service.",
-            "",
-        ],
-        ["", "", ""],
-        ["Non-goal", "", ""],
-        [
-            "Per-building EB / EPMC residual / BAT_epmc reconstruction",
-            (
-                "Out of scope. These are produced upstream by CAIRO from ResStock hourly loads + marginal "
-                "cost shapes; reconstructing them in spreadsheet formulas across ~131k buildings x 8760 hours "
-                "is infeasible. See rate-design-platform/context/methods/bat_mc_residual/epmc_and_supply_allocation.md "
-                "and utils/post/build_master_bat.py for the upstream methodology."
-            ),
             "",
         ],
         ["", "", ""],
@@ -335,17 +329,19 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
             "annual_fixed_per_customer ($)",
             inputs["annual_fixed_per_customer"],
             (
-                "Derived: (total_delivery_revenue_requirement - default_vol_usd_per_kwh "
-                "* test_year_residential_kwh) / test_year_customer_count."
+                "Test-year revenue equation: (total_RR - vol_rate * total_kWh) / customers. "
+                "Inputs from RIE Docket 25-45-GE, Book 21, PRB-1-ELEC p. 14, lines 8-9 "
+                "(Blazunas Schedules, Nov 2025)."
             ),
         ],
     ]
     for r in rows:
         ws.append(r)
     ws["A1"].font = Font(bold=True, size=14)
-    for header_row in (3, 11, 19, 27, 30):
+    # Section-header rows: adjust if rows above change.
+    for header_row in (3, 9, 16, 24):
         _header_fill(ws, header_row, 3)
-    for label_row in range(31, 36):
+    for label_row in range(25, 30):
         _bold(ws, f"A{label_row}")
     _autosize(ws, {"A": 42, "B": 70, "C": 80})
     ws.sheet_view.showGridLines = False
@@ -389,8 +385,8 @@ def _write_inputs_revenue_requirement(wb: Workbook, inputs: dict) -> None:
         [
             "annual_fixed_per_customer",
             f"=({REF_TOTAL_RR} - {REF_DEFAULT_VOL} * {REF_TY_KWH}) / {REF_N_CUSTOMERS}",
-            "Derived in this workbook",
-            "Annual non-volumetric delivery charges per customer (customer charge + fixed top-ups). Validated: annual_kwh * vol_rate + this value ≈ annual_bill_delivery.",
+            "Test-year revenue equation (RIE Docket 25-45-GE, Book 21, PRB-1-ELEC p. 14)",
+            "Annual non-volumetric delivery charges per customer. Per-customer share of delivery revenue not recovered through volumetric rates.",
         ],
         [
             "DISPLAY_CUSTOMER_TOTAL",
@@ -398,12 +394,29 @@ def _write_inputs_revenue_requirement(wb: Workbook, inputs: dict) -> None:
             "Derived in this workbook",
             "Integer total used for largest-remainder customer display rounding.",
         ],
+        [
+            "sum_weighted_eb",
+            inputs["sum_weighted_eb"],
+            "Computed from per-building data",
+            "Sum of (weight * economic_burden_delivery) across all buildings. Total weighted marginal cost recovered if every customer paid exactly their economic burden.",
+        ],
+        [
+            "total_residual",
+            f"={REF_TOTAL_RR} - {REF_SUM_WEIGHTED_EB}",
+            "Derived in this workbook",
+            "Revenue requirement not recovered by marginal costs alone. This residual pool is allocated back to each building proportionally to their economic burden (EPMC method).",
+        ],
+        [
+            "epmc_rate",
+            f"={REF_TOTAL_RESIDUAL} / {REF_SUM_WEIGHTED_EB}",
+            "Derived in this workbook",
+            "Residual allocation rate ($/$ of EB). Each building's residual share = economic_burden * epmc_rate. Mirrors CAIRO: epmc_rate = Residual Costs / sum(EB * weight).",
+        ],
     ]
     for r in rows:
         ws.append(r)
     _header_fill(ws, 1, 4)
     _autosize(ws, {"A": 36, "B": 22, "C": 70, "D": 70})
-    # Named ranges (workbook-scoped) referencing column B.
     for row, name in [
         (2, "total_delivery_revenue_requirement"),
         (3, "test_year_customer_count"),
@@ -412,6 +425,9 @@ def _write_inputs_revenue_requirement(wb: Workbook, inputs: dict) -> None:
         (6, "core_delivery_rate_total"),
         (7, "annual_fixed_per_customer"),
         (8, "DISPLAY_CUSTOMER_TOTAL"),
+        (9, "sum_weighted_eb"),
+        (10, "total_residual"),
+        (11, "epmc_rate"),
     ]:
         wb.defined_names[name] = DefinedName(
             name=name,
@@ -428,7 +444,7 @@ def _write_inputs_tariffs(wb: Workbook, inputs: dict) -> None:
             "default_vol_usd_per_kwh",
             inputs["default_vol_usd_per_kwh"],
             _rdp_permalink(f"{RDP_TARIFF_DIR}/rie_default_calibrated.json"),
-            "Field: energyratestructure[0][0].rate. Status-quo uniform default delivery $/kWh. Used in the BAT pipeline to back out annual kWh per building from the delivery bill.",
+            "Field: energyratestructure[0][0].rate. Status-quo uniform default delivery $/kWh.",
         ],
     ]
     for r in rows:
@@ -443,7 +459,7 @@ def _write_inputs_tariffs(wb: Workbook, inputs: dict) -> None:
 
 
 def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
-    """Write per-building BAT rows + formula columns. Returns last data row index."""
+    """Write per-building rows with EPMC formula columns. Returns last data row."""
     ws = wb.create_sheet("bat_per_building")
     headers = [
         "bldg_id",
@@ -455,11 +471,10 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
         "BAT_epmc_delivery",
         "cost_of_service_delivery",
         "annual_kwh",
-        "annual_bill_delivery_check",
-        "w_revenue",
-        "w_cos",
-        "w_xs",
-        "w_kwh",
+        "weighted_bill",
+        "weighted_cos",
+        "weighted_cross_subsidy",
+        "weighted_kwh",
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
@@ -473,8 +488,6 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
             "postprocess_group.heating_type_v2",
             "annual_bill_delivery",
             "economic_burden_delivery",
-            "residual_share_epmc_delivery",
-            "BAT_epmc_delivery",
             "annual_kwh",
         ).iter_rows()
     )
@@ -484,34 +497,34 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
         ws.cell(row=i, column=3, value=row[2])
         ws.cell(row=i, column=4, value=float(row[3]))
         ws.cell(row=i, column=5, value=float(row[4]))
-        ws.cell(row=i, column=6, value=float(row[5]))
-        ws.cell(row=i, column=7, value=float(row[6]))
+        ws.cell(row=i, column=6, value=f"=E{i}*{REF_EPMC_RATE}")
+        ws.cell(row=i, column=7, value=f"=D{i}-(E{i}+F{i})")
         ws.cell(row=i, column=8, value=f"=E{i}+F{i}")
-        ws.cell(row=i, column=9, value=float(row[7]))
-        ws.cell(row=i, column=10, value=f"=I{i}*{REF_DEFAULT_VOL}+{REF_ANNUAL_FIXED_PER_CUSTOMER}")
-        ws.cell(row=i, column=11, value=f"=B{i}*D{i}")
-        ws.cell(row=i, column=12, value=f"=B{i}*H{i}")
-        ws.cell(row=i, column=13, value=f"=B{i}*G{i}")
-        ws.cell(row=i, column=14, value=f"=B{i}*I{i}")
+        ws.cell(row=i, column=9, value=float(row[5]))
+        ws.cell(row=i, column=10, value=f"=B{i}*D{i}")
+        ws.cell(row=i, column=11, value=f"=B{i}*H{i}")
+        ws.cell(row=i, column=12, value=f"=B{i}*G{i}")
+        ws.cell(row=i, column=13, value=f"=B{i}*I{i}")
 
     last_row = 1 + n
-    widths = {
-        "A": 10,
-        "B": 10,
-        "C": 22,
-        "D": 18,
-        "E": 22,
-        "F": 22,
-        "G": 18,
-        "H": 22,
-        "I": 14,
-        "J": 24,
-        "K": 16,
-        "L": 16,
-        "M": 14,
-        "N": 16,
-    }
-    _autosize(ws, widths)
+    _autosize(
+        ws,
+        {
+            "A": 10,
+            "B": 10,
+            "C": 22,
+            "D": 18,
+            "E": 22,
+            "F": 26,
+            "G": 18,
+            "H": 22,
+            "I": 14,
+            "J": 16,
+            "K": 16,
+            "L": 22,
+            "M": 16,
+        },
+    )
 
     col_to_name = {
         "B": "ws_weight",
@@ -520,11 +533,10 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
         "G": "ws_BAT_epmc",
         "H": "ws_cos",
         "I": "ws_annual_kwh",
-        "J": "ws_bill_check",
-        "K": "ws_w_revenue",
-        "L": "ws_w_cos",
-        "M": "ws_w_xs",
-        "N": "ws_w_kwh",
+        "J": "ws_weighted_bill",
+        "K": "ws_weighted_cos",
+        "L": "ws_weighted_cross_subsidy",
+        "M": "ws_weighted_kwh",
     }
     for col, name in col_to_name.items():
         wb.defined_names[name] = DefinedName(
@@ -561,10 +573,10 @@ def _write_subclass_aggregates(wb: Workbook, last_bat_row: int) -> None:
     last = last_bat_row
     rng_weight = f"bat_per_building!$B$2:$B${last}"
     rng_heating = f"bat_per_building!$C$2:$C${last}"
-    rng_w_revenue = f"bat_per_building!$K$2:$K${last}"
-    rng_w_cos = f"bat_per_building!$L$2:$L${last}"
-    rng_w_xs = f"bat_per_building!$M$2:$M${last}"
-    rng_w_kwh = f"bat_per_building!$N$2:$N${last}"
+    rng_w_revenue = f"bat_per_building!$J$2:$J${last}"
+    rng_w_cos = f"bat_per_building!$K$2:$K${last}"
+    rng_w_xs = f"bat_per_building!$L$2:$L${last}"
+    rng_w_kwh = f"bat_per_building!$M$2:$M${last}"
     sub_last = 1 + n_sub  # Last subclass data row index.
 
     # Subclass rows.
@@ -745,70 +757,104 @@ def _write_fig15_published(wb: Workbook) -> None:
     ws.sheet_view.showGridLines = False
 
 
-def _write_validation(wb: Workbook, last_bat_row: int) -> None:
-    ws = wb.create_sheet("validation")
-    headers = ["check", "actual", "expected", "abs_error", "tolerance", "ok"]
-    ws.append(headers)
-    _header_fill(ws, 1, len(headers))
+def _validate_against_published(bat: pl.DataFrame, inputs: dict) -> None:
+    """Assert that weighted aggregates match published Figure 15 and EPMC formulas."""
+    import numpy as np
 
-    last = last_bat_row
-    rng_weight = f"bat_per_building!$B$2:$B${last}"
-    rng_bill = f"bat_per_building!$D$2:$D${last}"
-    rng_xs = f"bat_per_building!$G$2:$G${last}"
-    rng_cos = f"bat_per_building!$H$2:$H${last}"
-    rng_kwh = f"bat_per_building!$I$2:$I${last}"
+    total_w = float(bat["weight"].sum())
+    total_rev = float((bat["weight"] * bat["annual_bill_delivery"]).sum())
+    total_kwh = float((bat["weight"] * bat["annual_kwh"]).sum())
 
-    rows = [
-        (
-            "sum(weight) approx test_year_customer_count",
-            f"=SUM({rng_weight})",
-            f"={REF_N_CUSTOMERS}",
-            None,
-            0.05,
-        ),
-        (
-            "sum(weight x delivery_bill) approx total_delivery_revenue_requirement",
-            f"=SUMPRODUCT({rng_weight}, {rng_bill})",
-            f"={REF_TOTAL_RR}",
-            None,
-            2000.0,
-        ),
-        (
-            "sum(weight x BAT_epmc) approx 0 (cross-subsidy nets to zero)",
-            f"=SUMPRODUCT({rng_weight}, {rng_xs})",
-            "=0",
-            None,
-            5000.0,
-        ),
-        (
-            "sum(weight x cost_of_service) approx total_delivery_revenue_requirement",
-            f"=SUMPRODUCT({rng_weight}, {rng_cos})",
-            f"={REF_TOTAL_RR}",
-            None,
-            5000.0,
-        ),
-        (
-            "sum(weight x annual_kwh) approx test_year_residential_kwh",
-            f"=SUMPRODUCT({rng_weight}, {rng_kwh})",
-            f"={REF_TY_KWH}",
-            None,
-            1.0,
-        ),
-    ]
-    for i, (name, actual, expected, _err, tol) in enumerate(rows, start=2):
-        ws.cell(row=i, column=1, value=name)
-        ws.cell(row=i, column=2, value=actual)
-        ws.cell(row=i, column=3, value=expected)
-        ws.cell(row=i, column=4, value=f"=ABS(B{i}-C{i})")
-        ws.cell(row=i, column=5, value=tol)
-        ws.cell(row=i, column=6, value=f'=IF(D{i}<=E{i}, "OK", "FAIL")')
+    # --- Aggregate totals ---
+    assert abs(total_w - inputs["test_year_customer_count"]) < 0.5, (
+        f"sum(weight) = {total_w:,.2f} vs test_year_customer_count = {inputs['test_year_customer_count']:,.2f}"
+    )
+    assert abs(total_rev - inputs["total_delivery_revenue_requirement"]) < 2_000, (
+        f"sum(w*bill) = ${total_rev:,.0f} vs total_delivery_RR = ${inputs['total_delivery_revenue_requirement']:,.0f}"
+    )
+    assert abs(total_kwh - inputs["test_year_residential_kwh"]) < 1.0, (
+        f"sum(w*kwh) = {total_kwh:,.0f} vs test_year_residential_kwh = {inputs['test_year_residential_kwh']:,.0f}"
+    )
+    print("  Aggregate totals: PASS", flush=True)
 
-    _autosize(ws, {"A": 70, "B": 22, "C": 22, "D": 16, "E": 14, "F": 8})
-    for r in range(2, 2 + len(rows)):
-        ws[f"B{r}"].number_format = "#,##0.00"
-        ws[f"C{r}"].number_format = "#,##0.00"
-        ws[f"D{r}"].number_format = "#,##0.00"
-    ws.sheet_view.showGridLines = False
+    # --- EPMC formula validation ---
+    # Verify that the EPMC formula (EB * (RR/sum_w_EB - 1)) reproduces the
+    # parquet's residual_share_epmc_delivery per building.
+    sum_weighted_eb = float((bat["weight"] * bat["economic_burden_delivery"]).sum())
+    epmc_mult = inputs["total_delivery_revenue_requirement"] / sum_weighted_eb
+    derived_residual = bat["economic_burden_delivery"] * (epmc_mult - 1)
+    parquet_residual = bat["residual_share_epmc_delivery"]
+    max_residual_err = float((derived_residual - parquet_residual).abs().max())
+    assert max_residual_err < 0.01, f"EPMC residual: max per-building error = {max_residual_err:.6f} (tol = 0.01)"
+
+    derived_cos = bat["economic_burden_delivery"] + derived_residual
+    derived_bat = bat["annual_bill_delivery"] - derived_cos
+    parquet_bat = bat["BAT_epmc_delivery"]
+    max_bat_err = float((derived_bat - parquet_bat).abs().max())
+    assert max_bat_err < 0.01, f"EPMC BAT: max per-building error = {max_bat_err:.6f} (tol = 0.01)"
+    print(
+        f"  EPMC formula: PASS (residual max err = {max_residual_err:.2e}, BAT max err = {max_bat_err:.2e})",
+        flush=True,
+    )
+
+    # --- Published Figure 15 values ---
+    pkl_path = Path(__file__).resolve().parents[1] / "cache" / "report_variables_cos_subclass.pkl"
+    assert pkl_path.exists(), f"Missing {pkl_path}. Render cost_of_service_by_subclass.qmd first."
+    v = SimpleNamespace(**pickle.loads(pkl_path.read_bytes()))
+
+    # Per-subclass total COS, revenue, cross-subsidy.
+    bat_v = bat.with_columns(
+        derived_cos.alias("_derived_cos"),
+        derived_bat.alias("_derived_bat"),
+    )
+    by_ht = bat_v.group_by("postprocess_group.heating_type_v2").agg(
+        pl.col("weight").sum().alias("n_customers"),
+        (pl.col("weight") * pl.col("annual_bill_delivery")).sum().alias("revenue_delivery"),
+        (pl.col("weight") * pl.col("annual_kwh")).sum().alias("total_kwh"),
+        (pl.col("weight") * pl.col("_derived_cos")).sum().alias("cost_of_service"),
+        (pl.col("weight") * pl.col("_derived_bat")).sum().alias("cross_subsidy"),
+    )
+    actual = {row["postprocess_group.heating_type_v2"]: row for row in by_ht.iter_rows(named=True)}
+
+    pub_map = {"hp": "heat_pump", "ng": "natgas", "df": "delivered_fuels", "er": "electrical_resistance"}
+    for short, key in pub_map.items():
+        pub_cos = getattr(v, f"cos_default_{short}_group_cos")
+        pub_rev = getattr(v, f"cos_default_{short}_group_rev")
+        pub_xs = getattr(v, f"cos_default_{short}_group_xs")
+        a = actual[key]
+        label = HT_V2_LABELS[key]
+        assert abs(a["cost_of_service"] - pub_cos) < 500, (
+            f"{label}: COS ${a['cost_of_service']:,.0f} != published ${pub_cos:,.0f}"
+        )
+        assert abs(a["revenue_delivery"] - pub_rev) < 500, (
+            f"{label}: revenue ${a['revenue_delivery']:,.0f} != published ${pub_rev:,.0f}"
+        )
+        assert abs(a["cross_subsidy"] - pub_xs) < 500, (
+            f"{label}: cross-subsidy ${a['cross_subsidy']:,.0f} != published ${pub_xs:,.0f}"
+        )
+
+    # Customer display counts (largest-remainder rounding).
+    published_rows: list[dict] = v.testimony_subclass_delivery_rows
+    display_total = round(inputs["test_year_customer_count"])
+    sub_weights = [actual[k]["n_customers"] for k in HT_V2_ORDER]
+    raw_counts = np.array(sub_weights) * display_total / total_w
+    floors = np.floor(raw_counts).astype(np.int64)
+    remainder = display_total - int(floors.sum())
+    order = np.argsort(-(raw_counts - floors))
+    for k in range(remainder):
+        floors[order[k]] += 1
+
+    for pub_row in published_rows:
+        sub_name = pub_row["subclass"]
+        if sub_name == "All customers":
+            continue
+        key = next(k for k, v_label in HT_V2_LABELS.items() if v_label == sub_name)
+        idx = list(HT_V2_ORDER).index(key)
+        wb_customers = int(floors[idx])
+        pub_customers = int(pub_row["n_customers_display"])
+        assert wb_customers == pub_customers, f"{sub_name}: customers {wb_customers} != published {pub_customers}"
+
+    print("  Figure 15 replication: PASS (all subclass values match published)", flush=True)
 
 
 def build_workbook(output_path: Path) -> Path:
@@ -831,31 +877,26 @@ def build_workbook(output_path: Path) -> Path:
         ).alias("annual_kwh")
     )
 
-    _weighted_kwh = float((bat["weight"] * bat["annual_kwh"]).sum())
-    _kwh_err = abs(_weighted_kwh - inputs["test_year_residential_kwh"])
-    assert _kwh_err < 1.0, (
-        f"sum(weight * annual_kwh) = {_weighted_kwh:,.0f} vs test_year_residential_kwh "
-        f"= {inputs['test_year_residential_kwh']:,.0f}; error = {_kwh_err:,.2f}"
-    )
-    print(f"  annual_kwh derived from bills (aggregate kWh error = {_kwh_err:.4f})", flush=True)
+    inputs["sum_weighted_eb"] = float((bat["weight"] * bat["economic_burden_delivery"]).sum())
+    print(f"  sum_weighted_eb = ${inputs['sum_weighted_eb']:,.0f}", flush=True)
+
+    print("Validating against published Figure 15 and EPMC formulas ...", flush=True)
+    _validate_against_published(bat, inputs)
 
     wb = Workbook()
-    # Remove the default empty sheet; we re-create README at index 0.
     default = wb.active
     if default is not None:
         wb.remove(default)
 
     # Sheet creation order is also the upload order. Put inputs_tariffs before
     # inputs_revenue_requirement so that the latter's annual_fixed_per_customer
-    # formula (which references inputs_tariffs!$B$2) resolves at upload time
-    # rather than caching an "Unresolved sheet name" error in Sheets.
+    # formula (which references inputs_tariffs!$B$2) resolves at upload time.
     _write_readme(wb, inputs)
     _write_inputs_tariffs(wb, inputs)
     _write_inputs_revenue_requirement(wb, inputs)
     last_bat_row = _write_bat_per_building(wb, bat)
     _write_subclass_aggregates(wb, last_bat_row)
     _write_fig15_published(wb)
-    _write_validation(wb, last_bat_row)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     wb.save(str(output_path))
@@ -871,7 +912,7 @@ _TAB_FORMATTING: dict[str, dict] = {
         "bold_header": True,
         # Section-header rows inside the README; must stay in sync with the row
         # offsets used by _header_fill in _write_readme.
-        "bold_rows": [3, 11, 19, 27, 30],
+        "bold_rows": [3, 9, 16, 24],
     },
     "inputs_revenue_requirement": {
         "column_number_formats": {"B": "#,##0.00"},
@@ -897,13 +938,12 @@ _TAB_FORMATTING: dict[str, dict] = {
             "G": '"$"#,##0.00',
             "H": '"$"#,##0.00',
             "I": "#,##0.00",
-            "J": '"$"#,##0.00',
+            "J": "#,##0.00",
             "K": "#,##0.00",
             "L": "#,##0.00",
             "M": "#,##0.00",
-            "N": "#,##0.00",
         },
-        "auto_resize_columns": ["A:N"],
+        "auto_resize_columns": ["A:M"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -936,12 +976,6 @@ _TAB_FORMATTING: dict[str, dict] = {
         },
         "auto_resize_columns": ["A:G"],
         "freeze_rows": 4,
-        "bold_header": True,
-    },
-    "validation": {
-        "column_number_formats": {"B": "#,##0.00", "C": "#,##0.00", "D": "#,##0.00"},
-        "auto_resize_columns": ["A:F"],
-        "freeze_rows": 1,
         "bold_header": True,
     },
 }

--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_11_DIV_7_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_11_DIV_7_workbook.py
@@ -70,6 +70,13 @@ RDP_REV_YAML_PATH = "rate_design/hp_rates/ri/config/rev_requirement/rie_rate_cas
 RDP_TARIFF_DIR = "rate_design/hp_rates/ri/config/tariffs/electric"
 RDP_GITHUB_BASE = "https://github.com/switchbox-data/rate-design-platform/blob"
 
+FIXED_CHARGE_PER_MONTH = 10.01
+FIXED_CHARGE_PER_YEAR = FIXED_CHARGE_PER_MONTH * 12
+
+KWH_BATCH = "ri_20260504_kwh_export_v2"
+_KWH_BASE = f"{S3_BASE}/{STATE_LOWER}/{UTILITY}/{KWH_BATCH}"
+PATH_KWH_U0 = f"{_KWH_BASE}/20260505_011359_ri_rie_run1_up00_precalc__default/billing_kwh_annual.parquet"
+
 
 def _rdp_permalink(rel_path: str) -> str:
     """SHA-pinned GitHub permalink for a rate-design-platform file."""
@@ -148,6 +155,11 @@ def load_master_bat() -> pl.DataFrame:
     return df
 
 
+def _load_billing_kwh(path: str) -> pl.DataFrame:
+    """Load exported billing kWh (annual grid-consumed electricity)."""
+    return pl.read_parquet(path).select("bldg_id", "annual_kwh_grid")
+
+
 def load_inputs() -> dict:
     """Pull revenue-requirement YAML + calibrated tariff JSONs from rate-design-platform."""
     raw_yaml = fetch_rdp_file(RDP_REV_YAML_PATH, RDP_REF)
@@ -167,8 +179,6 @@ def load_inputs() -> dict:
 
     default_vol = vol_rate("rie_default_calibrated.json")
 
-    annual_fixed_per_customer = (total_rr - default_vol * ty_kwh) / n_customers
-
     return {
         "total_delivery_revenue_requirement": total_rr,
         "test_year_customer_count": n_customers,
@@ -176,7 +186,7 @@ def load_inputs() -> dict:
         "customer_charge_total": customer_charge_total,
         "core_delivery_rate_total": core_delivery_total,
         "default_vol_usd_per_kwh": default_vol,
-        "annual_fixed_per_customer": annual_fixed_per_customer,
+        "annual_fixed_per_customer": FIXED_CHARGE_PER_YEAR,
     }
 
 
@@ -254,9 +264,10 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
             (
                 "One row per residential building. Data columns: bldg_id, weight, heating_type_v2, "
                 "annual_bill_delivery, economic_burden_delivery (from CAIRO), and annual_kwh "
-                "(back-derived from delivery bill). Formula columns: "
-                "residual_share_epmc_delivery (= EB * epmc_rate), "
+                "(CAIRO billing kWh export: grid-consumed kWh after PV clipping and kwh_scale_factor). "
+                "Formula columns: residual_share_epmc_delivery (= EB * epmc_rate), "
                 "BAT_epmc_delivery (= bill - COS), cost_of_service_delivery (= EB + residual_share), "
+                "bill_formula (= kwh * vol + fixed, verifies bill), bill_residual (= bill - bill_formula), "
                 "and weighted_* products for aggregation."
             ),
             "",
@@ -329,9 +340,17 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
             "annual_fixed_per_customer ($)",
             inputs["annual_fixed_per_customer"],
             (
-                "Test-year revenue equation: (total_RR - vol_rate * total_kWh) / customers. "
-                "Inputs from RIE Docket 25-45-GE, Book 21, PRB-1-ELEC p. 14, lines 8-9 "
-                "(Blazunas Schedules, Nov 2025)."
+                f"Calibrated tariff: fixedchargefirstmeter = ${FIXED_CHARGE_PER_MONTH}/mo x 12. "
+                "Customer charge ($6.00) + RE Growth ($3.22) + LIHEAP Enhancement ($0.79). "
+                "Matches rie_default_calibrated.json."
+            ),
+        ],
+        [
+            "billing kWh (upgrade 0)",
+            PATH_KWH_U0,
+            (
+                "CAIRO billing pipeline export: annual grid-consumed kWh per building "
+                "(max(electricity_net, 0) per hour, after kwh_scale_factor and 48h timeshift)."
             ),
         ],
     ]
@@ -341,7 +360,7 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
     # Section-header rows: adjust if rows above change.
     for header_row in (3, 9, 16, 24):
         _header_fill(ws, header_row, 3)
-    for label_row in range(25, 30):
+    for label_row in range(25, 31):
         _bold(ws, f"A{label_row}")
     _autosize(ws, {"A": 42, "B": 70, "C": 80})
     ws.sheet_view.showGridLines = False
@@ -384,9 +403,10 @@ def _write_inputs_revenue_requirement(wb: Workbook, inputs: dict) -> None:
         ],
         [
             "annual_fixed_per_customer",
-            f"=({REF_TOTAL_RR} - {REF_DEFAULT_VOL} * {REF_TY_KWH}) / {REF_N_CUSTOMERS}",
-            "Test-year revenue equation (RIE Docket 25-45-GE, Book 21, PRB-1-ELEC p. 14)",
-            "Annual non-volumetric delivery charges per customer. Per-customer share of delivery revenue not recovered through volumetric rates.",
+            FIXED_CHARGE_PER_YEAR,
+            _rdp_permalink(f"{RDP_TARIFF_DIR}/rie_default_calibrated.json"),
+            f"Calibrated tariff: fixedchargefirstmeter = ${FIXED_CHARGE_PER_MONTH}/mo x 12 = ${FIXED_CHARGE_PER_YEAR}/yr. "
+            "Customer charge ($6.00) + RE Growth ($3.22) + LIHEAP Enhancement ($0.79).",
         ],
         [
             "DISPLAY_CUSTOMER_TOTAL",
@@ -462,19 +482,21 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
     """Write per-building rows with EPMC formula columns. Returns last data row."""
     ws = wb.create_sheet("bat_per_building")
     headers = [
-        "bldg_id",
-        "weight",
-        "heating_type_v2",
-        "annual_bill_delivery",
-        "economic_burden_delivery",
-        "residual_share_epmc_delivery",
-        "BAT_epmc_delivery",
-        "cost_of_service_delivery",
-        "annual_kwh",
-        "weighted_bill",
-        "weighted_cos",
-        "weighted_cross_subsidy",
-        "weighted_kwh",
+        "bldg_id",  # A
+        "weight",  # B
+        "heating_type_v2",  # C
+        "annual_bill_delivery",  # D  DATA
+        "economic_burden_delivery",  # E  DATA
+        "residual_share_epmc_delivery",  # F  FORMULA
+        "BAT_epmc_delivery",  # G  FORMULA
+        "cost_of_service_delivery",  # H  FORMULA
+        "annual_kwh",  # I  DATA (CAIRO export)
+        "bill_formula",  # J  FORMULA (kwh * vol + fixed)
+        "bill_residual",  # K  FORMULA (bill - bill_formula)
+        "weighted_bill",  # L  FORMULA
+        "weighted_cos",  # M  FORMULA
+        "weighted_cross_subsidy",  # N  FORMULA
+        "weighted_kwh",  # O  FORMULA
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
@@ -492,19 +514,21 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
         ).iter_rows()
     )
     for i, row in enumerate(rows, start=2):
-        ws.cell(row=i, column=1, value=row[0])
-        ws.cell(row=i, column=2, value=float(row[1]))
-        ws.cell(row=i, column=3, value=row[2])
-        ws.cell(row=i, column=4, value=float(row[3]))
-        ws.cell(row=i, column=5, value=float(row[4]))
-        ws.cell(row=i, column=6, value=f"=E{i}*{REF_EPMC_RATE}")
-        ws.cell(row=i, column=7, value=f"=D{i}-(E{i}+F{i})")
-        ws.cell(row=i, column=8, value=f"=E{i}+F{i}")
-        ws.cell(row=i, column=9, value=float(row[5]))
-        ws.cell(row=i, column=10, value=f"=B{i}*D{i}")
-        ws.cell(row=i, column=11, value=f"=B{i}*H{i}")
-        ws.cell(row=i, column=12, value=f"=B{i}*G{i}")
-        ws.cell(row=i, column=13, value=f"=B{i}*I{i}")
+        ws.cell(row=i, column=1, value=row[0])  # A: bldg_id
+        ws.cell(row=i, column=2, value=float(row[1]))  # B: weight
+        ws.cell(row=i, column=3, value=row[2])  # C: heating_type_v2
+        ws.cell(row=i, column=4, value=float(row[3]))  # D: annual_bill_delivery
+        ws.cell(row=i, column=5, value=float(row[4]))  # E: economic_burden_delivery
+        ws.cell(row=i, column=6, value=f"=E{i}*{REF_EPMC_RATE}")  # F: residual_share
+        ws.cell(row=i, column=7, value=f"=D{i}-(E{i}+F{i})")  # G: BAT_epmc
+        ws.cell(row=i, column=8, value=f"=E{i}+F{i}")  # H: COS
+        ws.cell(row=i, column=9, value=float(row[5]))  # I: annual_kwh
+        ws.cell(row=i, column=10, value=f"=I{i}*{REF_DEFAULT_VOL}+{REF_ANNUAL_FIXED_PER_CUSTOMER}")  # J: bill_formula
+        ws.cell(row=i, column=11, value=f"=D{i}-J{i}")  # K: bill_residual
+        ws.cell(row=i, column=12, value=f"=B{i}*D{i}")  # L: weighted_bill
+        ws.cell(row=i, column=13, value=f"=B{i}*H{i}")  # M: weighted_cos
+        ws.cell(row=i, column=14, value=f"=B{i}*G{i}")  # N: weighted_cross_subsidy
+        ws.cell(row=i, column=15, value=f"=B{i}*I{i}")  # O: weighted_kwh
 
     last_row = 1 + n
     _autosize(
@@ -521,8 +545,10 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
             "I": 14,
             "J": 16,
             "K": 16,
-            "L": 22,
+            "L": 16,
             "M": 16,
+            "N": 22,
+            "O": 16,
         },
     )
 
@@ -533,10 +559,10 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
         "G": "ws_BAT_epmc",
         "H": "ws_cos",
         "I": "ws_annual_kwh",
-        "J": "ws_weighted_bill",
-        "K": "ws_weighted_cos",
-        "L": "ws_weighted_cross_subsidy",
-        "M": "ws_weighted_kwh",
+        "L": "ws_weighted_bill",
+        "M": "ws_weighted_cos",
+        "N": "ws_weighted_cross_subsidy",
+        "O": "ws_weighted_kwh",
     }
     for col, name in col_to_name.items():
         wb.defined_names[name] = DefinedName(
@@ -573,10 +599,10 @@ def _write_subclass_aggregates(wb: Workbook, last_bat_row: int) -> None:
     last = last_bat_row
     rng_weight = f"bat_per_building!$B$2:$B${last}"
     rng_heating = f"bat_per_building!$C$2:$C${last}"
-    rng_w_revenue = f"bat_per_building!$J$2:$J${last}"
-    rng_w_cos = f"bat_per_building!$K$2:$K${last}"
-    rng_w_xs = f"bat_per_building!$L$2:$L${last}"
-    rng_w_kwh = f"bat_per_building!$M$2:$M${last}"
+    rng_w_revenue = f"bat_per_building!$L$2:$L${last}"
+    rng_w_cos = f"bat_per_building!$M$2:$M${last}"
+    rng_w_xs = f"bat_per_building!$N$2:$N${last}"
+    rng_w_kwh = f"bat_per_building!$O$2:$O${last}"
     sub_last = 1 + n_sub  # Last subclass data row index.
 
     # Subclass rows.
@@ -763,7 +789,6 @@ def _validate_against_published(bat: pl.DataFrame, inputs: dict) -> None:
 
     total_w = float(bat["weight"].sum())
     total_rev = float((bat["weight"] * bat["annual_bill_delivery"]).sum())
-    total_kwh = float((bat["weight"] * bat["annual_kwh"]).sum())
 
     # --- Aggregate totals ---
     assert abs(total_w - inputs["test_year_customer_count"]) < 0.5, (
@@ -772,10 +797,15 @@ def _validate_against_published(bat: pl.DataFrame, inputs: dict) -> None:
     assert abs(total_rev - inputs["total_delivery_revenue_requirement"]) < 2_000, (
         f"sum(w*bill) = ${total_rev:,.0f} vs total_delivery_RR = ${inputs['total_delivery_revenue_requirement']:,.0f}"
     )
-    assert abs(total_kwh - inputs["test_year_residential_kwh"]) < 1.0, (
-        f"sum(w*kwh) = {total_kwh:,.0f} vs test_year_residential_kwh = {inputs['test_year_residential_kwh']:,.0f}"
-    )
     print("  Aggregate totals: PASS", flush=True)
+
+    # --- Bill formula verification ---
+    # annual_kwh * vol_rate + annual_fixed should exactly reproduce annual_bill_delivery.
+    bill_check = bat["annual_kwh"] * inputs["default_vol_usd_per_kwh"] + FIXED_CHARGE_PER_YEAR
+    bill_err = (bat["annual_bill_delivery"] - bill_check).abs()
+    max_bill_err = float(bill_err.max())
+    assert max_bill_err < 0.01, f"Bill formula: max per-building error = ${max_bill_err:.6f} (tol = $0.01)"
+    print(f"  Bill formula: PASS (max err = ${max_bill_err:.2e})", flush=True)
 
     # --- EPMC formula validation ---
     # Verify that the EPMC formula (EB * (RR/sum_w_EB - 1)) reproduces the
@@ -871,11 +901,16 @@ def build_workbook(output_path: Path) -> Path:
     print(f"  default_vol_usd_per_kwh = {inputs['default_vol_usd_per_kwh']:.6f}", flush=True)
     print(f"  annual_fixed_per_customer = ${inputs['annual_fixed_per_customer']:,.2f}", flush=True)
 
-    bat = bat.with_columns(
-        (
-            (pl.col("annual_bill_delivery") - inputs["annual_fixed_per_customer"]) / inputs["default_vol_usd_per_kwh"]
-        ).alias("annual_kwh")
+    print(f"Loading billing kWh from {PATH_KWH_U0} ...", flush=True)
+    kwh = _load_billing_kwh(PATH_KWH_U0)
+    print(f"  {kwh.height:,} buildings, median {kwh['annual_kwh_grid'].median():,.0f} kWh", flush=True)
+
+    bat = bat.join(
+        kwh.select("bldg_id", pl.col("annual_kwh_grid").alias("annual_kwh")),
+        on="bldg_id",
+        how="left",
     )
+    assert bat["annual_kwh"].null_count() == 0, "Some buildings missing billing kWh"
 
     inputs["sum_weighted_eb"] = float((bat["weight"] * bat["economic_burden_delivery"]).sum())
     print(f"  sum_weighted_eb = ${inputs['sum_weighted_eb']:,.0f}", flush=True)
@@ -889,8 +924,8 @@ def build_workbook(output_path: Path) -> Path:
         wb.remove(default)
 
     # Sheet creation order is also the upload order. Put inputs_tariffs before
-    # inputs_revenue_requirement so that the latter's annual_fixed_per_customer
-    # formula (which references inputs_tariffs!$B$2) resolves at upload time.
+    # inputs_revenue_requirement so that cross-sheet references (e.g.
+    # bat_per_building formulas referencing inputs_tariffs!$B$2) resolve.
     _write_readme(wb, inputs)
     _write_inputs_tariffs(wb, inputs)
     _write_inputs_revenue_requirement(wb, inputs)
@@ -938,12 +973,14 @@ _TAB_FORMATTING: dict[str, dict] = {
             "G": '"$"#,##0.00',
             "H": '"$"#,##0.00',
             "I": "#,##0.00",
-            "J": "#,##0.00",
-            "K": "#,##0.00",
+            "J": '"$"#,##0.00',
+            "K": '"$"#,##0.00',
             "L": "#,##0.00",
             "M": "#,##0.00",
+            "N": "#,##0.00",
+            "O": "#,##0.00",
         },
-        "auto_resize_columns": ["A:M"],
+        "auto_resize_columns": ["A:O"],
         "freeze_rows": 1,
         "bold_header": True,
     },

--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_12_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_12_workbook.py
@@ -133,9 +133,6 @@ def _write_readme(wb: Workbook) -> None:
     ws["A8"] = "Analysis notebook"
     ws["B8"] = _reports2_permalink("reports/ri_hp_rates/notebooks/cost_of_service_by_subclass.qmd")
 
-    ws["A9"] = "This workbook's build script"
-    ws["B9"] = _reports2_permalink("reports/ri_hp_rates/testimony_response/build_RIE_1_12_workbook.py")
-
     _autosize(ws, {"A": 30, "B": 100})
     ws.sheet_view.showGridLines = False
 

--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_5_DIV_1_1_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_5_DIV_1_1_workbook.py
@@ -5,7 +5,7 @@ Figure 2 in the Pre-Filed Direct Testimony of Juan-Pablo Velez (page 10,
 breakdown of customers, consumption, and delivery revenue by residential
 heating subclass for the test year (9/1/24 to 8/31/25).
 
-This script reproduces every published number from per-building BAT outputs
+This script reproduces every published number from per-building CAIRO outputs
 plus a small set of revenue-requirement and tariff inputs, with **live
 formulas** in every aggregation cell. The output is an ``.xlsx`` that opens
 identically in Excel and Google Sheets; with ``--upload`` the same workbook is
@@ -25,9 +25,11 @@ formulas instead of polars group-by/sum.
 from __future__ import annotations
 
 import argparse
+import pickle
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import polars as pl
 import yaml
@@ -114,7 +116,7 @@ HT_V2_LABELS: dict[str, str] = {
 
 
 def load_master_bat() -> pl.DataFrame:
-    """Mirror ``load_master_bat`` in ``cost_of_service_by_subclass.qmd``."""
+    """Load per-building BAT data for RIE (delivery bills and weights only)."""
     df = (
         pl.scan_parquet(PATH_MASTER_BAT_12, hive_partitioning=True)
         .filter(pl.col("sb.electric_utility") == UTILITY)
@@ -123,9 +125,6 @@ def load_master_bat() -> pl.DataFrame:
             "weight",
             "postprocess_group.heating_type_v2",
             "annual_bill_delivery",
-            "economic_burden_delivery",
-            "residual_share_epmc_delivery",
-            "BAT_epmc_delivery",
         )
         .collect()
     )
@@ -181,6 +180,9 @@ def _autosize(ws, widths: dict[str, int]) -> None:
         ws.column_dimensions[col].width = w
 
 
+# ---------------------------------------------------------------------------
+# Sheet writers.
+# ---------------------------------------------------------------------------
 def _write_readme(wb: Workbook, inputs: dict) -> None:
     ws = wb.create_sheet("README", 0)
     s3_bat = f"{S3_BASE}/{STATE_LOWER}/all_utilities/{BATCH}/run_1+2/cross_subsidization_BAT_values/"
@@ -189,14 +191,9 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         ["", "", ""],
         ["Item", "Source", "Notes"],
         [
-            "Per-building BAT outputs",
+            "Per-building CAIRO outputs",
             s3_bat,
-            "CAIRO batch outputs (one row per RIE residential building) used as the per-building basis for all weighted aggregates.",
-        ],
-        [
-            "CAIRO batch",
-            BATCH,
-            "RIE test-year status-quo batch (run_1+2 = uniform default delivery + supply for all customers).",
+            "One row per residential building under the status-quo uniform default delivery + supply rate for all customers. Used as the per-building basis for all weighted aggregates.",
         ],
         [
             "Revenue-requirement YAML",
@@ -231,28 +228,22 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
             "",
         ],
         [
-            "bat_per_building",
+            "bill_per_building",
             (
-                "One row per RIE residential building. Columns from CAIRO BAT parquet, "
-                "annual_kwh back-derived from delivery bill (= (annual_bill_delivery - annual_fixed_per_customer) / vol_rate), "
-                "plus formula columns: cost_of_service_delivery, annual_bill_delivery_check (= annual_kwh * vol_rate + annual_fixed_per_customer), "
-                "and weighted aggregates. weight is uniform: test_year_customer_count / n_buildings (each building represents the same number of customers)."
+                "One row per residential building. Columns: bldg_id, weight (calibrated to test_year_customer_count), "
+                "heating_type_v2, annual_kwh, annual_bill_delivery (= annual_kwh * vol_rate + annual_fixed_per_customer), "
+                "w_revenue (= weight * annual_bill_delivery), w_kwh (= weight * annual_kwh)."
             ),
             "",
         ],
         [
             "subclass_aggregates",
-            "Five subclass rows + 'All customers' total via live SUMIFS / SUMPRODUCT over bat_per_building. Includes consumption_gwh, pct_all_consumption, and pct_all_revenue alongside the largest-remainder customer display columns.",
+            "Five subclass rows + 'All customers' total via live SUMIFS / SUMPRODUCT over bill_per_building. Includes consumption_gwh, pct_all_consumption, and pct_all_revenue alongside the largest-remainder customer display columns.",
             "",
         ],
         [
             "fig2_published",
             "Final published layout: customers, % of customers, consumption (GWh), % of consumption, delivery revenue, % of revenue.",
-            "",
-        ],
-        [
-            "validation",
-            "Formula-level checks that mirror the polars asserts in the notebook (sum of weights, total revenue, cross-subsidy nets to zero, derived total kWh, derived total GWh).",
             "",
         ],
         ["", "", ""],
@@ -284,18 +275,6 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
             "",
         ],
         ["", "", ""],
-        ["Non-goal", "", ""],
-        [
-            "Per-building EB / EPMC residual / BAT_epmc reconstruction",
-            (
-                "Out of scope. These are produced upstream by CAIRO from ResStock hourly loads + marginal "
-                "cost shapes; reconstructing them in spreadsheet formulas across ~131k buildings x 8760 hours "
-                "is infeasible. See rate-design-platform/context/methods/bat_mc_residual/epmc_and_supply_allocation.md "
-                "and utils/post/build_master_bat.py for the upstream methodology."
-            ),
-            "",
-        ],
-        ["", "", ""],
         ["Key inputs (also live in inputs_revenue_requirement / inputs_tariffs)", "Value", "Source"],
         [
             "total_delivery_revenue_requirement ($)",
@@ -309,7 +288,7 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
         [
             "test_year_customer_count",
             inputs["test_year_customer_count"],
-            ("PRB-1-ELEC exhibit, p. 14, lines 8-9, column d. 5,032,174 bills / 12 = 419,347.83 customers."),
+            "PRB-1-ELEC exhibit, p. 14, lines 8-9, column d. 5,032,174 bills / 12 = 419,347.83 customers.",
         ],
         [
             "test_year_residential_kwh",
@@ -325,21 +304,19 @@ def _write_readme(wb: Workbook, inputs: dict) -> None:
             "annual_fixed_per_customer ($)",
             inputs["annual_fixed_per_customer"],
             (
-                "Derived: (total_delivery_revenue_requirement - default_vol_usd_per_kwh "
-                "* test_year_residential_kwh) / test_year_customer_count."
+                "Test-year revenue equation: (total_RR - vol_rate * total_kWh) / customers. "
+                "Inputs from RIE Docket 25-45-GE, Book 21, PRB-1-ELEC p. 14, lines 8-9 "
+                "(Blazunas Schedules, Nov 2025)."
             ),
         ],
     ]
     for r in rows:
         ws.append(r)
     ws["A1"].font = Font(bold=True, size=14)
-    # Section-header rows: title=1, item header=3, sheet header=11,
-    # column header=19, non-goal header=27, key inputs header=30. The
-    # "fig2_published column" section has 6 rows (Figure 15 has 6 too) so
-    # offsets match. Confirmed against the rows[] indices above.
-    for header_row in (3, 11, 19, 27, 30):
+    # Section headers: item=3, sheets=10, columns=17, key inputs=25.
+    for header_row in (3, 10, 17, 25):
         _header_fill(ws, header_row, 3)
-    for label_row in range(31, 36):
+    for label_row in range(26, 31):
         _bold(ws, f"A{label_row}")
     _autosize(ws, {"A": 42, "B": 70, "C": 80})
     ws.sheet_view.showGridLines = False
@@ -383,8 +360,8 @@ def _write_inputs_revenue_requirement(wb: Workbook, inputs: dict) -> None:
         [
             "annual_fixed_per_customer",
             f"=({REF_TOTAL_RR} - {REF_DEFAULT_VOL} * {REF_TY_KWH}) / {REF_N_CUSTOMERS}",
-            "Derived in this workbook",
-            "Annual non-volumetric delivery charges per customer (customer charge + fixed top-ups). Validated: annual_kwh * vol_rate + this value ≈ annual_bill_delivery.",
+            "Test-year revenue equation (RIE Docket 25-45-GE, Book 21, PRB-1-ELEC p. 14)",
+            "Annual non-volumetric delivery charges per customer. Per-customer share of delivery revenue not recovered through volumetric rates.",
         ],
         [
             "DISPLAY_CUSTOMER_TOTAL",
@@ -421,7 +398,7 @@ def _write_inputs_tariffs(wb: Workbook, inputs: dict) -> None:
             "default_vol_usd_per_kwh",
             inputs["default_vol_usd_per_kwh"],
             _rdp_permalink(f"{RDP_TARIFF_DIR}/rie_default_calibrated.json"),
-            "Field: energyratestructure[0][0].rate. Status-quo uniform default delivery $/kWh. Used in the BAT pipeline to back out annual kWh per building from the delivery bill.",
+            "Field: energyratestructure[0][0].rate. Status-quo uniform default delivery $/kWh.",
         ],
     ]
     for r in rows:
@@ -435,24 +412,17 @@ def _write_inputs_tariffs(wb: Workbook, inputs: dict) -> None:
     ws.sheet_view.showGridLines = False
 
 
-def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
-    """Write per-building BAT rows + formula columns. Returns last data row index."""
-    ws = wb.create_sheet("bat_per_building")
+def _write_bill_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
+    """Write per-building rows + formula columns. Returns last data row index."""
+    ws = wb.create_sheet("bill_per_building")
     headers = [
-        "bldg_id",
-        "weight",
-        "heating_type_v2",
-        "annual_bill_delivery",
-        "economic_burden_delivery",
-        "residual_share_epmc_delivery",
-        "BAT_epmc_delivery",
-        "cost_of_service_delivery",
-        "annual_kwh",
-        "annual_bill_delivery_check",
-        "w_revenue",
-        "w_cos",
-        "w_xs",
-        "w_kwh",
+        "bldg_id",  # A
+        "weight",  # B
+        "heating_type_v2",  # C
+        "annual_kwh",  # D  data
+        "annual_bill_delivery",  # E  formula = D * vol_rate + fixed
+        "w_revenue",  # F  formula = B * E
+        "w_kwh",  # G  formula = B * D
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
@@ -464,65 +434,33 @@ def _write_bat_per_building(wb: Workbook, bat: pl.DataFrame) -> int:
             "bldg_id",
             "weight",
             "postprocess_group.heating_type_v2",
-            "annual_bill_delivery",
-            "economic_burden_delivery",
-            "residual_share_epmc_delivery",
-            "BAT_epmc_delivery",
             "annual_kwh",
         ).iter_rows()
     )
     for i, row in enumerate(rows, start=2):
-        ws.cell(row=i, column=1, value=row[0])
-        ws.cell(row=i, column=2, value=float(row[1]))
-        ws.cell(row=i, column=3, value=row[2])
-        ws.cell(row=i, column=4, value=float(row[3]))
-        ws.cell(row=i, column=5, value=float(row[4]))
-        ws.cell(row=i, column=6, value=float(row[5]))
-        ws.cell(row=i, column=7, value=float(row[6]))
-        ws.cell(row=i, column=8, value=f"=E{i}+F{i}")
-        ws.cell(row=i, column=9, value=float(row[7]))
-        ws.cell(row=i, column=10, value=f"=I{i}*{REF_DEFAULT_VOL}+{REF_ANNUAL_FIXED_PER_CUSTOMER}")
-        ws.cell(row=i, column=11, value=f"=B{i}*D{i}")
-        ws.cell(row=i, column=12, value=f"=B{i}*H{i}")
-        ws.cell(row=i, column=13, value=f"=B{i}*G{i}")
-        ws.cell(row=i, column=14, value=f"=B{i}*I{i}")
+        ws.cell(row=i, column=1, value=row[0])  # A: bldg_id
+        ws.cell(row=i, column=2, value=float(row[1]))  # B: weight
+        ws.cell(row=i, column=3, value=row[2])  # C: heating_type_v2
+        ws.cell(row=i, column=4, value=float(row[3]))  # D: annual_kwh
+        ws.cell(row=i, column=5, value=f"=D{i}*{REF_DEFAULT_VOL}+{REF_ANNUAL_FIXED_PER_CUSTOMER}")
+        ws.cell(row=i, column=6, value=f"=B{i}*E{i}")  # F: w_revenue
+        ws.cell(row=i, column=7, value=f"=B{i}*D{i}")  # G: w_kwh
 
     last_row = 1 + n
-    widths = {
-        "A": 10,
-        "B": 10,
-        "C": 22,
-        "D": 18,
-        "E": 22,
-        "F": 22,
-        "G": 18,
-        "H": 22,
-        "I": 14,
-        "J": 24,
-        "K": 16,
-        "L": 16,
-        "M": 14,
-        "N": 16,
-    }
-    _autosize(ws, widths)
+    _autosize(ws, {"A": 10, "B": 10, "C": 22, "D": 14, "E": 18, "F": 16, "G": 16})
 
     col_to_name = {
         "B": "ws_weight",
         "C": "ws_heating_type",
-        "D": "ws_annual_bill",
-        "G": "ws_BAT_epmc",
-        "H": "ws_cos",
-        "I": "ws_annual_kwh",
-        "J": "ws_bill_check",
-        "K": "ws_w_revenue",
-        "L": "ws_w_cos",
-        "M": "ws_w_xs",
-        "N": "ws_w_kwh",
+        "D": "ws_annual_kwh",
+        "E": "ws_annual_bill",
+        "F": "ws_w_revenue",
+        "G": "ws_w_kwh",
     }
     for col, name in col_to_name.items():
         wb.defined_names[name] = DefinedName(
             name=name,
-            attr_text=f"bat_per_building!${col}$2:${col}${last_row}",
+            attr_text=f"bill_per_building!${col}$2:${col}${last_row}",
         )
     return last_row
 
@@ -534,18 +472,16 @@ def _write_subclass_aggregates(wb: Workbook, last_bat_row: int) -> None:
         "subclass",  # B
         "n_customers",  # C
         "revenue_delivery",  # D
-        "cost_of_service",  # E
-        "cross_subsidy",  # F
-        "total_kwh",  # G
-        "raw_display_count",  # H
-        "floor_display_count",  # I
-        "remainder",  # J
-        "rank_remainder",  # K
-        "n_customers_display",  # L
-        "pct_customers_display",  # M
-        "consumption_gwh",  # N -- new for Figure 2
-        "pct_all_consumption",  # O -- new for Figure 2
-        "pct_all_revenue",  # P -- new for Figure 2
+        "total_kwh",  # E
+        "raw_display_count",  # F
+        "floor_display_count",  # G
+        "remainder",  # H
+        "rank_remainder",  # I
+        "n_customers_display",  # J
+        "pct_customers_display",  # K
+        "consumption_gwh",  # L
+        "pct_all_consumption",  # M
+        "pct_all_revenue",  # N
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
@@ -553,12 +489,10 @@ def _write_subclass_aggregates(wb: Workbook, last_bat_row: int) -> None:
     n_sub = len(HT_V2_ORDER)
 
     last = last_bat_row
-    rng_weight = f"bat_per_building!$B$2:$B${last}"
-    rng_heating = f"bat_per_building!$C$2:$C${last}"
-    rng_w_revenue = f"bat_per_building!$K$2:$K${last}"
-    rng_w_cos = f"bat_per_building!$L$2:$L${last}"
-    rng_w_xs = f"bat_per_building!$M$2:$M${last}"
-    rng_w_kwh = f"bat_per_building!$N$2:$N${last}"
+    rng_weight = f"bill_per_building!$B$2:$B${last}"
+    rng_heating = f"bill_per_building!$C$2:$C${last}"
+    rng_w_revenue = f"bill_per_building!$F$2:$F${last}"
+    rng_w_kwh = f"bill_per_building!$G$2:$G${last}"
     sub_last = 1 + n_sub
     total_row = 2 + n_sub
 
@@ -568,65 +502,47 @@ def _write_subclass_aggregates(wb: Workbook, last_bat_row: int) -> None:
         ws.cell(row=row, column=2, value=HT_V2_LABELS[key])
         ws.cell(row=row, column=3, value=f"=SUMIFS({rng_weight}, {rng_heating}, A{row})")
         ws.cell(row=row, column=4, value=f"=SUMIFS({rng_w_revenue}, {rng_heating}, A{row})")
-        ws.cell(row=row, column=5, value=f"=SUMIFS({rng_w_cos}, {rng_heating}, A{row})")
-        ws.cell(row=row, column=6, value=f"=SUMIFS({rng_w_xs}, {rng_heating}, A{row})")
-        ws.cell(row=row, column=7, value=f"=SUMIFS({rng_w_kwh}, {rng_heating}, A{row})")
-        ws.cell(
-            row=row,
-            column=8,
-            value=f"=C{row}*{REF_DISPLAY_TOTAL}/SUM($C$2:$C${sub_last})",
-        )
-        ws.cell(row=row, column=9, value=f"=INT(H{row})")
-        ws.cell(row=row, column=10, value=f"=H{row}-I{row}")
-        ws.cell(row=row, column=11, value=f"=RANK(J{row},$J$2:$J${sub_last})")
-        ws.cell(
-            row=row,
-            column=12,
-            value=f"=I{row}+IF(K{row}<={REF_DISPLAY_TOTAL}-SUM($I$2:$I${sub_last}),1,0)",
-        )
-        ws.cell(row=row, column=13, value=f"=L{row}/{REF_DISPLAY_TOTAL}")
-        # Figure 2 columns: consumption_gwh, pct_all_consumption, pct_all_revenue.
-        # Reference the "All customers" total row (G{total_row}, D{total_row})
-        # so the percentages always sum to 100% within the worksheet.
-        ws.cell(row=row, column=14, value=f"=G{row}/1000000")
-        ws.cell(row=row, column=15, value=f"=G{row}/$G${total_row}")
-        ws.cell(row=row, column=16, value=f"=D{row}/$D${total_row}")
+        ws.cell(row=row, column=5, value=f"=SUMIFS({rng_w_kwh}, {rng_heating}, A{row})")
+        ws.cell(row=row, column=6, value=f"=C{row}*{REF_DISPLAY_TOTAL}/SUM($C$2:$C${sub_last})")
+        ws.cell(row=row, column=7, value=f"=INT(F{row})")
+        ws.cell(row=row, column=8, value=f"=F{row}-G{row}")
+        ws.cell(row=row, column=9, value=f"=RANK(H{row},$H$2:$H${sub_last})")
+        ws.cell(row=row, column=10, value=f"=G{row}+IF(I{row}<={REF_DISPLAY_TOTAL}-SUM($G$2:$G${sub_last}),1,0)")
+        ws.cell(row=row, column=11, value=f"=J{row}/{REF_DISPLAY_TOTAL}")
+        ws.cell(row=row, column=12, value=f"=E{row}/1000000")
+        ws.cell(row=row, column=13, value=f"=E{row}/$E${total_row}")
+        ws.cell(row=row, column=14, value=f"=D{row}/$D${total_row}")
 
     ws.cell(row=total_row, column=1, value="all_customers")
     ws.cell(row=total_row, column=2, value="All customers")
     ws.cell(row=total_row, column=3, value=f"=SUM({rng_weight})")
     ws.cell(row=total_row, column=4, value=f"=SUM({rng_w_revenue})")
-    ws.cell(row=total_row, column=5, value=f"=SUM({rng_w_cos})")
-    ws.cell(row=total_row, column=6, value=f"=SUM({rng_w_xs})")
-    ws.cell(row=total_row, column=7, value=f"=SUM({rng_w_kwh})")
-    ws.cell(row=total_row, column=8, value=f"={REF_DISPLAY_TOTAL}")
-    ws.cell(row=total_row, column=9, value=f"={REF_DISPLAY_TOTAL}")
-    ws.cell(row=total_row, column=10, value=0)
-    ws.cell(row=total_row, column=11, value="")
-    ws.cell(row=total_row, column=12, value=f"={REF_DISPLAY_TOTAL}")
+    ws.cell(row=total_row, column=5, value=f"=SUM({rng_w_kwh})")
+    ws.cell(row=total_row, column=6, value=f"={REF_DISPLAY_TOTAL}")
+    ws.cell(row=total_row, column=7, value=f"={REF_DISPLAY_TOTAL}")
+    ws.cell(row=total_row, column=8, value=0)
+    ws.cell(row=total_row, column=9, value="")
+    ws.cell(row=total_row, column=10, value=f"={REF_DISPLAY_TOTAL}")
+    ws.cell(row=total_row, column=11, value=1)
+    ws.cell(row=total_row, column=12, value=f"=E{total_row}/1000000")
     ws.cell(row=total_row, column=13, value=1)
-    ws.cell(row=total_row, column=14, value=f"=G{total_row}/1000000")
-    ws.cell(row=total_row, column=15, value=1)
-    ws.cell(row=total_row, column=16, value=1)
+    ws.cell(row=total_row, column=14, value=1)
 
     _bold(ws, f"A{total_row}")
     _bold(ws, f"B{total_row}")
 
-    money_cols = ("D", "E", "F")
-    for c in money_cols:
-        for r in range(2, total_row + 1):
-            ws[f"{c}{r}"].number_format = '"$"#,##0'
     for r in range(2, total_row + 1):
         ws[f"C{r}"].number_format = "#,##0.0"
+        ws[f"D{r}"].number_format = '"$"#,##0'
+        ws[f"E{r}"].number_format = "#,##0"
+        ws[f"F{r}"].number_format = "#,##0.00"
         ws[f"G{r}"].number_format = "#,##0"
         ws[f"H{r}"].number_format = "#,##0.00"
-        ws[f"I{r}"].number_format = "#,##0"
-        ws[f"J{r}"].number_format = "#,##0.00"
-        ws[f"L{r}"].number_format = "#,##0"
+        ws[f"J{r}"].number_format = "#,##0"
+        ws[f"K{r}"].number_format = "0.0%"
+        ws[f"L{r}"].number_format = "#,##0.0"
         ws[f"M{r}"].number_format = "0.0%"
-        ws[f"N{r}"].number_format = "#,##0.0"
-        ws[f"O{r}"].number_format = "0.0%"
-        ws[f"P{r}"].number_format = "0.0%"
+        ws[f"N{r}"].number_format = "0.0%"
 
     _autosize(
         ws,
@@ -636,17 +552,15 @@ def _write_subclass_aggregates(wb: Workbook, last_bat_row: int) -> None:
             "C": 16,
             "D": 18,
             "E": 18,
-            "F": 16,
-            "G": 18,
-            "H": 14,
-            "I": 14,
-            "J": 12,
-            "K": 8,
+            "F": 14,
+            "G": 14,
+            "H": 12,
+            "I": 8,
+            "J": 14,
+            "K": 14,
             "L": 14,
-            "M": 14,
+            "M": 16,
             "N": 14,
-            "O": 16,
-            "P": 14,
         },
     )
     ws.freeze_panes = "C2"
@@ -664,7 +578,7 @@ def _write_fig2_published(wb: Workbook) -> None:
     title = "Customers, consumption, and delivery revenue by residential subclass"
     subtitle = (
         "RIE Test Year (9/1/2024 to 8/31/2025). Source: cost_of_service_by_subclass.qmd "
-        "(tbl-testimony-subclass-delivery) and the per-building BAT outputs documented in README. "
+        "(tbl-testimony-subclass-delivery) and the per-building CAIRO outputs documented in README. "
         "Embedded as Figure 2 on page 10 of the Pre-Filed Direct Testimony of Juan-Pablo Velez."
     )
     ws["A1"] = title
@@ -694,12 +608,12 @@ def _write_fig2_published(wb: Workbook) -> None:
         agg_row = 1 + i
         out_row = header_row + i
         ws.cell(row=out_row, column=1, value=f"=subclass_aggregates!B{agg_row}")
-        ws.cell(row=out_row, column=2, value=f"=subclass_aggregates!L{agg_row}")
-        ws.cell(row=out_row, column=3, value=f"=subclass_aggregates!M{agg_row}")
-        ws.cell(row=out_row, column=4, value=f"=subclass_aggregates!N{agg_row}")
-        ws.cell(row=out_row, column=5, value=f"=subclass_aggregates!O{agg_row}")
+        ws.cell(row=out_row, column=2, value=f"=subclass_aggregates!J{agg_row}")
+        ws.cell(row=out_row, column=3, value=f"=subclass_aggregates!K{agg_row}")
+        ws.cell(row=out_row, column=4, value=f"=subclass_aggregates!L{agg_row}")
+        ws.cell(row=out_row, column=5, value=f"=subclass_aggregates!M{agg_row}")
         ws.cell(row=out_row, column=6, value=f"=subclass_aggregates!D{agg_row}")
-        ws.cell(row=out_row, column=7, value=f"=subclass_aggregates!P{agg_row}")
+        ws.cell(row=out_row, column=7, value=f"=subclass_aggregates!N{agg_row}")
 
     n_rows = len(rows)
     last_data_row = header_row + n_rows
@@ -719,97 +633,103 @@ def _write_fig2_published(wb: Workbook) -> None:
         for r in range(header_row + 1, last_data_row + 1):
             ws.cell(row=r, column=c).alignment = Alignment(horizontal="center")
 
-    _autosize(
-        ws,
-        {
-            "A": 24,
-            "B": 14,
-            "C": 16,
-            "D": 16,
-            "E": 18,
-            "F": 18,
-            "G": 14,
-        },
+    _autosize(ws, {"A": 24, "B": 14, "C": 16, "D": 16, "E": 18, "F": 18, "G": 14})
+    ws.sheet_view.showGridLines = False
+
+
+# ---------------------------------------------------------------------------
+# Runtime validation against published Figure 2.
+# ---------------------------------------------------------------------------
+def _validate_against_published(bat: pl.DataFrame, inputs: dict) -> None:
+    """Assert that weighted aggregates match report_variables.pkl (Figure 2)."""
+    total_w = float(bat["weight"].sum())
+    total_rev = float((bat["weight"] * bat["annual_bill_delivery"]).sum())
+    total_kwh = float((bat["weight"] * bat["annual_kwh"]).sum())
+
+    # Aggregate totals.
+    assert abs(total_w - inputs["test_year_customer_count"]) < 0.5, (
+        f"sum(weight) = {total_w:,.2f} vs test_year_customer_count = {inputs['test_year_customer_count']:,.2f}"
     )
-    ws.sheet_view.showGridLines = False
+    assert abs(total_rev - inputs["total_delivery_revenue_requirement"]) < 2_000, (
+        f"sum(w*bill) = ${total_rev:,.0f} vs total_delivery_RR = ${inputs['total_delivery_revenue_requirement']:,.0f}"
+    )
+    assert abs(total_kwh - inputs["test_year_residential_kwh"]) < 1.0, (
+        f"sum(w*kwh) = {total_kwh:,.0f} vs test_year_residential_kwh = {inputs['test_year_residential_kwh']:,.0f}"
+    )
+    print("  Aggregate totals: PASS", flush=True)
+
+    # Per-subclass validation against the published Figure 2.
+    pkl_path = Path(__file__).resolve().parents[1] / "cache" / "report_variables_cos_subclass.pkl"
+    assert pkl_path.exists(), f"Missing {pkl_path}. Render cost_of_service_by_subclass.qmd first."
+    v = SimpleNamespace(**pickle.loads(pkl_path.read_bytes()))
+    published_rows: list[dict] = v.testimony_subclass_delivery_rows
+
+    by_ht = bat.group_by("postprocess_group.heating_type_v2").agg(
+        pl.col("weight").sum().alias("n_customers"),
+        (pl.col("weight") * pl.col("annual_bill_delivery")).sum().alias("revenue_delivery"),
+        (pl.col("weight") * pl.col("annual_kwh")).sum().alias("total_kwh"),
+    )
+    actual = {row["postprocess_group.heating_type_v2"]: row for row in by_ht.iter_rows(named=True)}
+
+    import numpy as np
+
+    # Reproduce largest-remainder rounding for customer display counts.
+    display_total = round(inputs["test_year_customer_count"])
+    sub_weights = [actual[k]["n_customers"] for k in HT_V2_ORDER]
+    raw_counts = np.array(sub_weights) * display_total / total_w
+    floors = np.floor(raw_counts).astype(np.int64)
+    remainder = display_total - int(floors.sum())
+    order = np.argsort(-(raw_counts - floors))
+    for k in range(remainder):
+        floors[order[k]] += 1
+
+    for pub_row in published_rows:
+        sub_name = pub_row["subclass"]
+        if sub_name == "All customers":
+            continue
+        key = next(k for k, v_label in HT_V2_LABELS.items() if v_label == sub_name)
+        idx = list(HT_V2_ORDER).index(key)
+        a = actual[key]
+
+        wb_customers = int(floors[idx])
+        pub_customers = int(pub_row["n_customers_display"])
+        assert wb_customers == pub_customers, f"{sub_name}: customers {wb_customers} != published {pub_customers}"
+
+        wb_gwh = a["total_kwh"] / 1_000_000.0
+        pub_gwh = float(pub_row["consumption_gwh"])
+        assert abs(wb_gwh - pub_gwh) < 0.05, f"{sub_name}: consumption {wb_gwh:.1f} GWh != published {pub_gwh:.1f} GWh"
+
+        wb_rev = a["revenue_delivery"]
+        pub_rev = float(pub_row["revenue_delivery"])
+        assert abs(wb_rev - pub_rev) < 1.0, f"{sub_name}: revenue ${wb_rev:,.0f} != published ${pub_rev:,.0f}"
+
+        wb_pct_cust = float(floors[idx]) / display_total
+        pub_pct_cust = float(pub_row["pct_customers_display"])
+        assert abs(wb_pct_cust - pub_pct_cust) < 0.001, (
+            f"{sub_name}: pct_customers {wb_pct_cust:.4f} != published {pub_pct_cust:.4f}"
+        )
+
+        wb_pct_cons = a["total_kwh"] / total_kwh
+        pub_pct_cons = float(pub_row["pct_all_consumption"])
+        assert abs(wb_pct_cons - pub_pct_cons) < 0.001, (
+            f"{sub_name}: pct_consumption {wb_pct_cons:.4f} != published {pub_pct_cons:.4f}"
+        )
+
+        wb_pct_rev = a["revenue_delivery"] / total_rev
+        pub_pct_rev = float(pub_row["pct_all_revenue"])
+        assert abs(wb_pct_rev - pub_pct_rev) < 0.001, (
+            f"{sub_name}: pct_revenue {wb_pct_rev:.4f} != published {pub_pct_rev:.4f}"
+        )
+
+    print("  Figure 2 replication: PASS (all subclass values match published)", flush=True)
 
 
-def _write_validation(wb: Workbook, last_bat_row: int) -> None:
-    ws = wb.create_sheet("validation")
-    headers = ["check", "actual", "expected", "abs_error", "tolerance", "ok"]
-    ws.append(headers)
-    _header_fill(ws, 1, len(headers))
-
-    last = last_bat_row
-    rng_weight = f"bat_per_building!$B$2:$B${last}"
-    rng_bill = f"bat_per_building!$D$2:$D${last}"
-    rng_xs = f"bat_per_building!$G$2:$G${last}"
-    rng_cos = f"bat_per_building!$H$2:$H${last}"
-    rng_kwh = f"bat_per_building!$I$2:$I${last}"
-
-    rows = [
-        (
-            "sum(weight) approx test_year_customer_count",
-            f"=SUM({rng_weight})",
-            f"={REF_N_CUSTOMERS}",
-            None,
-            0.05,
-        ),
-        (
-            "sum(weight x delivery_bill) approx total_delivery_revenue_requirement",
-            f"=SUMPRODUCT({rng_weight}, {rng_bill})",
-            f"={REF_TOTAL_RR}",
-            None,
-            2000.0,
-        ),
-        (
-            "sum(weight x BAT_epmc) approx 0 (cross-subsidy nets to zero)",
-            f"=SUMPRODUCT({rng_weight}, {rng_xs})",
-            "=0",
-            None,
-            5000.0,
-        ),
-        (
-            "sum(weight x cost_of_service) approx total_delivery_revenue_requirement",
-            f"=SUMPRODUCT({rng_weight}, {rng_cos})",
-            f"={REF_TOTAL_RR}",
-            None,
-            5000.0,
-        ),
-        (
-            "sum(weight x annual_kwh) approx test_year_residential_kwh",
-            f"=SUMPRODUCT({rng_weight}, {rng_kwh})",
-            f"={REF_TY_KWH}",
-            None,
-            1.0,
-        ),
-        (
-            "sum(weight x annual_kwh) / 1e6 approx total consumption_gwh in subclass_aggregates",
-            f"=SUMPRODUCT({rng_weight}, {rng_kwh})/1000000",
-            "=subclass_aggregates!N7",
-            None,
-            0.001,
-        ),
-    ]
-    for i, (name, actual, expected, _err, tol) in enumerate(rows, start=2):
-        ws.cell(row=i, column=1, value=name)
-        ws.cell(row=i, column=2, value=actual)
-        ws.cell(row=i, column=3, value=expected)
-        ws.cell(row=i, column=4, value=f"=ABS(B{i}-C{i})")
-        ws.cell(row=i, column=5, value=tol)
-        ws.cell(row=i, column=6, value=f'=IF(D{i}<=E{i}, "OK", "FAIL")')
-
-    _autosize(ws, {"A": 80, "B": 22, "C": 22, "D": 16, "E": 14, "F": 8})
-    for r in range(2, 2 + len(rows)):
-        ws[f"B{r}"].number_format = "#,##0.00"
-        ws[f"C{r}"].number_format = "#,##0.00"
-        ws[f"D{r}"].number_format = "#,##0.00"
-    ws.sheet_view.showGridLines = False
-
-
+# ---------------------------------------------------------------------------
+# Orchestration.
+# ---------------------------------------------------------------------------
 def build_workbook(output_path: Path) -> Path:
     """Build and save the .xlsx workbook. Returns the output path."""
-    print(f"Loading per-building BAT from {PATH_MASTER_BAT_12} ...", flush=True)
+    print(f"Loading per-building data from {PATH_MASTER_BAT_12} ...", flush=True)
     bat = load_master_bat()
     print(f"  {bat.height:,} rows", flush=True)
 
@@ -827,43 +747,36 @@ def build_workbook(output_path: Path) -> Path:
         ).alias("annual_kwh")
     )
 
-    _weighted_kwh = float((bat["weight"] * bat["annual_kwh"]).sum())
-    _kwh_err = abs(_weighted_kwh - inputs["test_year_residential_kwh"])
-    assert _kwh_err < 1.0, (
-        f"sum(weight * annual_kwh) = {_weighted_kwh:,.0f} vs test_year_residential_kwh "
-        f"= {inputs['test_year_residential_kwh']:,.0f}; error = {_kwh_err:,.2f}"
-    )
-    print(f"  annual_kwh derived from bills (aggregate kWh error = {_kwh_err:.4f})", flush=True)
+    print("Validating against published Figure 2 ...", flush=True)
+    _validate_against_published(bat, inputs)
 
     wb = Workbook()
     default = wb.active
     if default is not None:
         wb.remove(default)
 
-    # inputs_tariffs before inputs_revenue_requirement so the latter's
-    # annual_fixed_per_customer formula resolves at upload time.
     _write_readme(wb, inputs)
     _write_inputs_tariffs(wb, inputs)
     _write_inputs_revenue_requirement(wb, inputs)
-    last_bat_row = _write_bat_per_building(wb, bat)
+    last_bat_row = _write_bill_per_building(wb, bat)
     _write_subclass_aggregates(wb, last_bat_row)
     _write_fig2_published(wb)
-    _write_validation(wb, last_bat_row)
-
     output_path.parent.mkdir(parents=True, exist_ok=True)
     wb.save(str(output_path))
     print(f"Wrote {output_path} ({output_path.stat().st_size / 1024:.1f} KB)", flush=True)
     return output_path
 
 
+# ---------------------------------------------------------------------------
+# Google Sheets upload.
+# ---------------------------------------------------------------------------
 _TAB_FORMATTING: dict[str, dict] = {
     "README": {
         "wrap_columns": ["A:C"],
         "column_widths_px": {"A": 280, "B": 480, "C": 480},
         "freeze_rows": 1,
         "bold_header": True,
-        # Section-header rows; must stay in sync with _write_readme offsets.
-        "bold_rows": [3, 11, 19, 27, 30],
+        "bold_rows": [3, 10, 17, 25],
     },
     "inputs_revenue_requirement": {
         "column_number_formats": {"B": "#,##0.00"},
@@ -879,22 +792,15 @@ _TAB_FORMATTING: dict[str, dict] = {
         "freeze_rows": 1,
         "bold_header": True,
     },
-    "bat_per_building": {
+    "bill_per_building": {
         "column_number_formats": {
             "B": "#,##0.00",
-            "D": '"$"#,##0.00',
+            "D": "#,##0.00",
             "E": '"$"#,##0.00',
-            "F": '"$"#,##0.00',
-            "G": '"$"#,##0.00',
-            "H": '"$"#,##0.00',
-            "I": "#,##0.00",
-            "J": '"$"#,##0.00',
-            "K": "#,##0.00",
-            "L": "#,##0.00",
-            "M": "#,##0.00",
-            "N": "#,##0.00",
+            "F": "#,##0.00",
+            "G": "#,##0.00",
         },
-        "auto_resize_columns": ["A:N"],
+        "auto_resize_columns": ["A:G"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -902,20 +808,18 @@ _TAB_FORMATTING: dict[str, dict] = {
         "column_number_formats": {
             "C": "#,##0.00",
             "D": '"$"#,##0.00',
-            "E": '"$"#,##0.00',
-            "F": '"$"#,##0.00',
-            "G": "#,##0.00",
+            "E": "#,##0.00",
+            "F": "#,##0.00",
+            "G": "#,##0",
             "H": "#,##0.00",
             "I": "#,##0",
-            "J": "#,##0.00",
-            "K": "#,##0",
-            "L": "#,##0",
+            "J": "#,##0",
+            "K": "0.0%",
+            "L": "#,##0.0",
             "M": "0.0%",
-            "N": "#,##0.0",
-            "O": "0.0%",
-            "P": "0.0%",
+            "N": "0.0%",
         },
-        "auto_resize_columns": ["A:P"],
+        "auto_resize_columns": ["A:N"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -930,12 +834,6 @@ _TAB_FORMATTING: dict[str, dict] = {
         },
         "auto_resize_columns": ["A:G"],
         "freeze_rows": 4,
-        "bold_header": True,
-    },
-    "validation": {
-        "column_number_formats": {"B": "#,##0.00", "C": "#,##0.00", "D": "#,##0.00"},
-        "auto_resize_columns": ["A:F"],
-        "freeze_rows": 1,
         "bold_header": True,
     },
 }

--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_8_1_9_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_8_1_9_workbook.py
@@ -1,0 +1,851 @@
+"""Build workbooks for RIE 1-8 and RIE 1-9 discovery responses.
+
+RIE 1-8: "Under current default rates, 79% of gas-heated households
+in Rhode Island would lose money after switching to heat pumps."
+
+RIE 1-9: "With such rates 87% of gas-heated households would save
+money after switching to heat pumps."
+
+Both percentages use LMI-adjusted bills (32% enrollment tier).
+
+Run from the report directory::
+
+    uv run python -m testimony_response.build_RIE_1_8_1_9_workbook
+    uv run python -m testimony_response.build_RIE_1_8_1_9_workbook --upload
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import polars as pl
+import yaml
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Font, PatternFill
+
+from lib.rdp import fetch_rdp_file, parse_urdb_json
+
+# ---------------------------------------------------------------------------
+# Constants.
+# ---------------------------------------------------------------------------
+UTILITY = "rie"
+BATCH = "ri_20260331_r1-20_rate_case_test_year"
+S3_BASE = "s3://data.sb/switchbox/cairo/outputs/hp_rates"
+_state = "ri"
+
+PATH_BILLS_12 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_1+2/comb_bills_year_target/"
+PATH_BILLS_34 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_3+4/comb_bills_year_target/"
+PATH_BILLS_1920 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_19+20/comb_bills_year_target/"
+
+RDP_REF = "e9e5088"
+RDP_REV_YAML_PATH = "rate_design/hp_rates/ri/config/rev_requirement/rie_rate_case_test_year.yaml"
+RDP_TARIFF_DIR = "rate_design/hp_rates/ri/config/tariffs/electric"
+
+REPORTS2_GITHUB_BASE = "https://github.com/switchbox-data/reports2/blob"
+
+SPREADSHEET_1_8 = "1TEURpTKhM3ddpPagNxq1bT0oB24RyoorD4y7EVfFeUY"
+SPREADSHEET_1_9 = "1wocSf02gT7WS9G_vxs70d1SG1IOwhPLcUZGRuHXDRB8"
+
+BILL_COLS = [
+    "elec_total_bill",
+    "elec_total_bill_lmi_32",
+    "gas_total_bill",
+    "gas_total_bill_lmi_32",
+    "oil_total_bill",
+    "propane_total_bill",
+]
+KWH_COLS = ["elec_delivery_bill", "elec_fixed_charge"]
+LMI_BILL_COLS = [
+    "elec_total_bill_lmi_32",
+    "gas_total_bill_lmi_32",
+    "oil_total_bill",
+    "propane_total_bill",
+]
+
+# Scenario descriptions for the assumptions sheet.
+SCENARIOS: dict[str, dict[str, str]] = {
+    "1-8": {
+        "request": (
+            "RIE 1-8: Under current default rates, 79% of gas-heated "
+            "households in Rhode Island would lose money after switching "
+            "to heat pumps."
+        ),
+        "before_desc": "Run 1+2: Current HVAC, default delivery + supply rates",
+        "after_desc": "Run 3+4: Heat pump upgrade, same default rates",
+        "before_path": PATH_BILLS_12,
+        "after_path": PATH_BILLS_34,
+        "headline": "Percentage that LOSE money (1 - pct_save)",
+    },
+    "1-9": {
+        "request": (
+            "RIE 1-9: With such rates 87% of gas-heated households would save money after switching to heat pumps."
+        ),
+        "before_desc": "Run 1+2: Current HVAC, default delivery + supply rates",
+        "after_desc": "Run 19+20: Heat pump upgrade, proposed HP flat rate",
+        "before_path": PATH_BILLS_12,
+        "after_path": PATH_BILLS_1920,
+        "headline": "Percentage that SAVE money (pct_save)",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Permalink helpers.
+# ---------------------------------------------------------------------------
+def _reports2_head_sha() -> str:
+    if not hasattr(_reports2_head_sha, "_cached"):
+        repo_root = Path(__file__).resolve().parents[3]
+        sha = subprocess.check_output(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            text=True,
+        ).strip()
+        _reports2_head_sha._cached = sha  # type: ignore[attr-defined]
+    return _reports2_head_sha._cached  # type: ignore[attr-defined]
+
+
+def _reports2_permalink(rel_path: str) -> str:
+    return f"{REPORTS2_GITHUB_BASE}/{_reports2_head_sha()}/{rel_path}"
+
+
+# ---------------------------------------------------------------------------
+# Data loading.
+# ---------------------------------------------------------------------------
+def _load_annual_bills(path: str) -> pl.DataFrame:
+    """Load annual master bills for RIE, selecting only needed columns."""
+    lf = pl.scan_parquet(path, hive_partitioning=True)
+    result = (
+        lf.filter((pl.col("sb.electric_utility") == UTILITY) & (pl.col("month") == "Annual"))
+        .select(
+            "bldg_id",
+            "weight",
+            "heats_with_natgas",
+            *BILL_COLS,
+            *KWH_COLS,
+        )
+        .collect()
+    )
+    assert isinstance(result, pl.DataFrame)
+    return result
+
+
+def _load_inputs() -> dict:
+    """Pull revenue-requirement YAML, tariff rates, and report tariff-table values."""
+    import pickle
+
+    raw_yaml = fetch_rdp_file(RDP_REV_YAML_PATH, RDP_REF)
+    rev = yaml.safe_load(raw_yaml)
+    total_rr = float(rev["total_delivery_revenue_requirement"])
+    n_customers = float(rev["test_year_customer_count"])
+    ty_kwh = float(rev["test_year_residential_kwh"])
+
+    def _fetch_tariff(filename: str) -> dict:
+        return parse_urdb_json(fetch_rdp_file(f"{RDP_TARIFF_DIR}/{filename}", RDP_REF))
+
+    default_del = _fetch_tariff("rie_default_calibrated.json")
+    hp_flat_del = _fetch_tariff("rie_hp_flat_calibrated.json")
+    hp_flat_sup = _fetch_tariff("rie_hp_flat_supply_calibrated.json")
+
+    default_vol = float(default_del["items"][0]["energyratestructure"][0][0]["rate"])
+    annual_fixed_per_customer = (total_rr - default_vol * ty_kwh) / n_customers
+
+    rv = pickle.loads(Path("cache/report_variables.pkl").read_bytes())
+
+    return {
+        "default_vol_usd_per_kwh": default_vol,
+        "annual_fixed_per_customer": annual_fixed_per_customer,
+        "tariff_table": {
+            "elec_customer_charge": rv["elec_customer_charge"],
+            "elec_other_fixed_charges": rv["elec_other_fixed_charges"],
+            "elec_delivery_avg_cents": rv["elec_delivery_avg_cents"],
+            "elec_lrs_winter_cents": rv["elec_lrs_winter_cents"],
+            "elec_lrs_summer_cents": rv["elec_lrs_summer_cents"],
+            "elec_lrs_fall_cents": rv["elec_lrs_fall_cents"],
+            "gas_fixed_charge": rv["gas_fixed_charge"],
+            "gas_nonheating_fixed_charge": rv["gas_nonheating_fixed_charge"],
+            "gas_avg_per_therm": rv["gas_avg_per_therm"],
+            "gas_nonheating_avg_per_therm": rv["gas_nonheating_avg_per_therm"],
+            "hp_flat_delivery_cents": float(hp_flat_del["items"][0]["energyratestructure"][0][0]["rate"]) * 100,
+            "hp_flat_supply_cents": float(hp_flat_sup["items"][0]["energyratestructure"][0][0]["rate"]) * 100,
+        },
+    }
+
+
+def _derive_annual_kwh(bills: pl.DataFrame, inputs: dict) -> pl.DataFrame:
+    """Add annual_kwh column derived from the delivery bill components."""
+    return bills.with_columns(
+        (
+            (pl.col("elec_fixed_charge") + pl.col("elec_delivery_bill") - inputs["annual_fixed_per_customer"])
+            / inputs["default_vol_usd_per_kwh"]
+        ).alias("annual_kwh")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers.
+# ---------------------------------------------------------------------------
+def _header_fill(ws, row: int, n_cols: int) -> None:
+    fill = PatternFill("solid", fgColor="E8E8E8")
+    for c in range(1, n_cols + 1):
+        ws.cell(row=row, column=c).font = Font(bold=True)
+        ws.cell(row=row, column=c).fill = fill
+
+
+def _autosize(ws, widths: dict[str, int]) -> None:
+    for col, w in widths.items():
+        ws.column_dimensions[col].width = w
+
+
+# ---------------------------------------------------------------------------
+# Sheet writers.
+# ---------------------------------------------------------------------------
+def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
+    ws = wb.create_sheet("assumptions", 0)
+    scen = SCENARIOS[scenario_id]
+    tt = inputs["tariff_table"]
+
+    ws["A1"] = f"RIE {scenario_id} — Supporting calculation"
+    ws["A1"].font = Font(bold=True, size=14)
+    ws.merge_cells("A1:C1")
+
+    row = 3
+
+    # --- Key-value rows (2 columns) ----------------------------------------
+    kv_rows: list[tuple[str, str]] = [
+        ("Discovery request", scen["request"]),
+        ("", ""),
+        ("Assumptions", ""),
+        (
+            "LMI discount tier",
+            "32% enrollment (RI's current rate). The _lmi_32 bill columns "
+            "apply existing utility LMI discounts to enrolled low-income "
+            "households. Non-enrolled households see the undiscounted bill.",
+        ),
+        (
+            "Bill columns used",
+            "elec_total_bill_lmi_32 + gas_total_bill_lmi_32 + oil_total_bill + propane_total_bill",
+        ),
+        (
+            "Gas-heated filter",
+            "heats_with_natgas == true (ResStock heating fuel assignment)",
+        ),
+        (
+            "Save definition",
+            "delta < 0 (annual LMI-adjusted energy bill decreases after HP)",
+        ),
+        (
+            "Lose definition",
+            "delta > 0 (annual LMI-adjusted energy bill increases after HP)",
+        ),
+    ]
+    bold_labels = {"Assumptions", "Data sources", "per_building columns"}
+    for label, value in kv_rows:
+        ws.cell(row=row, column=1, value=label)
+        if label in bold_labels:
+            ws.cell(row=row, column=1).font = Font(bold=True)
+        ws.cell(row=row, column=2, value=value)
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+    # --- Tariff table (3 columns) -------------------------------------------
+    row += 1
+    ws.cell(row=row, column=1, value="Default tariffs (before)")
+    ws.cell(row=row, column=1).font = Font(bold=True)
+    cite = "Rhode Island Energy, Docket No. 2545-GE (2025). Blazunas Schedules & Workpapers, Book 21, PRB-1-ELEC."
+    ws.cell(row=row, column=2, value=cite)
+    ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+    row += 1
+
+    _header_fill(ws, row, 3)
+    for c, hdr in enumerate(["Tariff", "Fixed charge", "Volumetric rate"], 1):
+        ws.cell(row=row, column=c, value=hdr)
+    row += 1
+
+    default_tariff_rows: list[tuple[str, str, str]] = [
+        (
+            "Electricity — customer charge (A-16)",
+            f"${tt['elec_customer_charge']:.2f} /mo",
+            "—",
+        ),
+        (
+            "Electricity — RE Growth + LIHEAP (A-16)",
+            f"${tt['elec_other_fixed_charges']:.2f} /mo",
+            "—",
+        ),
+        (
+            "Electricity — delivery (A-16)",
+            "—",
+            f"{tt['elec_delivery_avg_cents']:.2f} ¢/kWh",
+        ),
+        (
+            "Electricity — supply, winter (LRS, Jan–Mar)",  # noqa: RUF001
+            "—",
+            f"{tt['elec_lrs_winter_cents']:.2f} ¢/kWh",
+        ),
+        (
+            "Electricity — supply, summer (LRS, Apr–Sep)",  # noqa: RUF001
+            "—",
+            f"{tt['elec_lrs_summer_cents']:.2f} ¢/kWh",
+        ),
+        (
+            "Electricity — supply, fall (LRS, Oct–Dec)",  # noqa: RUF001
+            "—",
+            f"{tt['elec_lrs_fall_cents']:.2f} ¢/kWh",
+        ),
+        (
+            "Natural gas — Rate 12 (heating)",
+            f"${tt['gas_fixed_charge']:.2f} /mo",
+            f"${tt['gas_avg_per_therm']:.3f} /therm",
+        ),
+        (
+            "Natural gas — Rate 10 (non-heating)",
+            f"${tt['gas_nonheating_fixed_charge']:.2f} /mo",
+            f"${tt['gas_nonheating_avg_per_therm']:.3f} /therm",
+        ),
+        ("Heating oil (EIA)", "—", "$3.48–$4.10 /gal (monthly prices)"),  # noqa: RUF001
+        ("Propane (EIA)", "—", "$3.44–$3.67 /gal (monthly prices)"),  # noqa: RUF001
+    ]
+    for tariff, fixed, vol in default_tariff_rows:
+        ws.cell(row=row, column=1, value=tariff)
+        ws.cell(row=row, column=2, value=fixed)
+        ws.cell(row=row, column=3, value=vol)
+        row += 1
+
+    # --- After tariffs (scenario-specific) ----------------------------------
+    if scenario_id == "1-9":
+        row += 1
+        ws.cell(row=row, column=1, value="HP subclass tariffs (after)")
+        ws.cell(row=row, column=1).font = Font(bold=True)
+        ws.cell(
+            row=row,
+            column=2,
+            value=(
+                "Delivery: EPMC allocation (revenue target reflects HP subclass cost-of-service). "
+                "Supply: per-customer allocation (each customer bears an equal share of supply revenue). "
+                "Gas, oil, and propane tariffs unchanged."
+            ),
+        )
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+        _header_fill(ws, row, 3)
+        for c, hdr in enumerate(["Tariff", "Fixed charge", "Volumetric rate"], 1):
+            ws.cell(row=row, column=c, value=hdr)
+        row += 1
+
+        hp_tariff_rows: list[tuple[str, str, str]] = [
+            (
+                "Electricity — customer charge",
+                f"${tt['elec_customer_charge']:.2f} /mo",
+                "—",
+            ),
+            (
+                "Electricity — RE Growth + LIHEAP",
+                f"${tt['elec_other_fixed_charges']:.2f} /mo",
+                "—",
+            ),
+            (
+                "Electricity — HP delivery (EPMC)",
+                "—",
+                f"{tt['hp_flat_delivery_cents']:.2f} ¢/kWh",
+            ),
+            (
+                "Electricity — HP supply (per-customer)",
+                "—",
+                f"{tt['hp_flat_supply_cents']:.2f} ¢/kWh",
+            ),
+        ]
+        for tariff, fixed, vol in hp_tariff_rows:
+            ws.cell(row=row, column=1, value=tariff)
+            ws.cell(row=row, column=2, value=fixed)
+            ws.cell(row=row, column=3, value=vol)
+            row += 1
+    else:
+        row += 1
+        ws.cell(row=row, column=1, value="After tariffs")
+        ws.cell(row=row, column=1).font = Font(bold=True)
+        ws.cell(
+            row=row,
+            column=2,
+            value="Same default tariffs as above (HP upgrade keeps current rates).",
+        )
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+    # --- Data sources -------------------------------------------------------
+    row += 1
+    ds_rows: list[tuple[str, str]] = [
+        ("Data sources", ""),
+        ("Before bills", f"{scen['before_desc']}\n{scen['before_path']}"),
+        ("After bills", f"{scen['after_desc']}\n{scen['after_path']}"),
+        (
+            "Analysis notebook",
+            _reports2_permalink("reports/ri_hp_rates/notebooks/analysis.qmd"),
+        ),
+    ]
+    for label, value in ds_rows:
+        ws.cell(row=row, column=1, value=label)
+        if label in bold_labels:
+            ws.cell(row=row, column=1).font = Font(bold=True)
+        ws.cell(row=row, column=2, value=value)
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+    # --- per_building columns -----------------------------------------------
+    row += 1
+    col_rows: list[tuple[str, str]] = [
+        ("per_building columns", ""),
+        ("bldg_id", "ResStock building identifier"),
+        ("weight", "CAIRO sample weight (number of real households this building represents)"),
+        (
+            "annual_kwh_before",
+            "Annual grid-consumed electricity (kWh), upgrade 0 (current HVAC). "
+            "Derived from delivery bill: (bill_delivery - annual_fixed_per_customer) / vol_rate. "
+            "Same derivation as RIE 1-5 workbook.",
+        ),
+        (
+            "annual_kwh_after",
+            "Annual grid-consumed electricity (kWh), upgrade 2 (heat pump). "
+            "Derived from run 3+4 delivery bills (default rate); "
+            "same physical consumption regardless of which tariff is applied.",
+        ),
+        ("elec_bill_before", "Annual electric bill before HP, undiscounted"),
+        (
+            "elec_bill_lmi_before",
+            "Annual electric bill before HP, with LMI discount applied (32% of eligible households receive discount)",
+        ),
+        ("gas_bill_before", "Annual gas bill before HP, undiscounted (same as LMI; gas has no LMI discount)"),
+        (
+            "gas_bill_lmi_before",
+            "Annual gas bill before HP, with LMI discount applied (32% of eligible households receive discount)",
+        ),
+        ("oil_bill_before", "Annual heating oil bill before HP (no LMI discount applies)"),
+        ("propane_bill_before", "Annual propane bill before HP (no LMI discount applies)"),
+        ("elec_bill_after", "Annual electric bill after HP, undiscounted"),
+        ("elec_bill_lmi_after", "Annual electric bill after HP, with LMI discount applied"),
+        ("gas_bill_after", "Annual gas bill after HP, undiscounted"),
+        ("gas_bill_lmi_after", "Annual gas bill after HP, with LMI discount applied"),
+        ("oil_bill_after", "Annual heating oil bill after HP"),
+        ("propane_bill_after", "Annual propane bill after HP"),
+        ("elec_lmi_discount_before", "Formula: elec_bill_before - elec_bill_lmi_before (discount amount)"),
+        ("elec_lmi_discount_after", "Formula: elec_bill_after - elec_bill_lmi_after (discount amount)"),
+        (
+            "energy_bill_lmi_before",
+            "Formula: sum of LMI-adjusted fuel bills before HP (elec_lmi + gas_lmi + oil + propane)",
+        ),
+        ("energy_bill_lmi_after", "Formula: sum of LMI-adjusted fuel bills after HP"),
+        ("delta", "Formula: energy_bill_lmi_after - energy_bill_lmi_before (negative = savings)"),
+        ("saves", "Formula: 1 if delta < 0, else 0"),
+        ("w_saves", "Formula: weight * saves (weighted savings indicator)"),
+    ]
+    for label, value in col_rows:
+        ws.cell(row=row, column=1, value=label)
+        if label in bold_labels:
+            ws.cell(row=row, column=1).font = Font(bold=True)
+        ws.cell(row=row, column=2, value=value)
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+    _autosize(ws, {"A": 44, "B": 40, "C": 36})
+    ws.sheet_view.showGridLines = False
+
+
+def _write_per_building(wb: Workbook, gas: pl.DataFrame) -> int:
+    """Write per-building bills sheet. Returns the last data row number."""
+    ws = wb.create_sheet("per_building")
+
+    headers = [
+        "bldg_id",  # A
+        "weight",  # B
+        "annual_kwh_before",  # C  data (upgrade 0)
+        "annual_kwh_after",  # D  data (upgrade 2)
+        "elec_bill_before",  # E
+        "elec_bill_lmi_before",  # F
+        "gas_bill_before",  # G
+        "gas_bill_lmi_before",  # H
+        "oil_bill_before",  # I
+        "propane_bill_before",  # J
+        "elec_bill_after",  # K
+        "elec_bill_lmi_after",  # L
+        "gas_bill_after",  # M
+        "gas_bill_lmi_after",  # N
+        "oil_bill_after",  # O
+        "propane_bill_after",  # P
+        "elec_lmi_discount_before",  # Q  formula
+        "elec_lmi_discount_after",  # R  formula
+        "energy_bill_lmi_before",  # S  formula
+        "energy_bill_lmi_after",  # T  formula
+        "delta",  # U  formula
+        "saves",  # V  formula
+        "w_saves",  # W  formula
+    ]
+    ws.append(headers)
+    _header_fill(ws, 1, len(headers))
+    ws.freeze_panes = "A2"
+
+    data_cols = [
+        "bldg_id",
+        "weight",
+        "annual_kwh_before",
+        "annual_kwh_after",
+        "elec_total_bill_before",
+        "elec_total_bill_lmi_32_before",
+        "gas_total_bill_before",
+        "gas_total_bill_lmi_32_before",
+        "oil_total_bill_before",
+        "propane_total_bill_before",
+        "elec_total_bill_after",
+        "elec_total_bill_lmi_32_after",
+        "gas_total_bill_after",
+        "gas_total_bill_lmi_32_after",
+        "oil_total_bill_after",
+        "propane_total_bill_after",
+    ]
+
+    rows = list(gas.select(data_cols).iter_rows())
+    for i, row in enumerate(rows, start=2):
+        for ci, val in enumerate(row, start=1):
+            ws.cell(row=i, column=ci, value=float(val) if ci > 1 else val)
+        # Q: elec LMI discount before = E - F
+        ws.cell(row=i, column=17, value=f"=E{i}-F{i}")
+        # R: elec LMI discount after = K - L
+        ws.cell(row=i, column=18, value=f"=K{i}-L{i}")
+        # S: energy_bill_lmi_before = F + H + I + J
+        ws.cell(row=i, column=19, value=f"=F{i}+H{i}+I{i}+J{i}")
+        # T: energy_bill_lmi_after = L + N + O + P
+        ws.cell(row=i, column=20, value=f"=L{i}+N{i}+O{i}+P{i}")
+        # U: delta = T - S
+        ws.cell(row=i, column=21, value=f"=T{i}-S{i}")
+        # V: saves = IF(U < 0, 1, 0)
+        ws.cell(row=i, column=22, value=f"=IF(U{i}<0,1,0)")
+        # W: w_saves = weight * saves
+        ws.cell(row=i, column=23, value=f"=B{i}*V{i}")
+
+    last_row = 1 + len(rows)
+
+    for r in range(2, last_row + 1):
+        for col in "CD":
+            ws[f"{col}{r}"].number_format = "#,##0"
+        for col in "EFGHIJKLMNOPQRSTU":
+            ws[f"{col}{r}"].number_format = '"$"#,##0.00'
+
+    _autosize(
+        ws,
+        {
+            "A": 10,
+            "B": 10,
+            "C": 18,
+            "D": 18,
+            "E": 16,
+            "F": 18,
+            "G": 16,
+            "H": 18,
+            "I": 14,
+            "J": 16,
+            "K": 16,
+            "L": 18,
+            "M": 16,
+            "N": 18,
+            "O": 14,
+            "P": 16,
+            "Q": 22,
+            "R": 22,
+            "S": 22,
+            "T": 22,
+            "U": 14,
+            "V": 8,
+            "W": 12,
+        },
+    )
+    return last_row
+
+
+def _write_result(wb: Workbook, last_row: int, scenario_id: str) -> None:
+    """Summary sheet deriving the headline percentage with formulas."""
+    ws = wb.create_sheet("result")
+    scen = SCENARIOS[scenario_id]
+
+    ws["A1"] = f"RIE {scenario_id} — Result"
+    ws["A1"].font = Font(bold=True, size=14)
+    ws.merge_cells("A1:C1")
+
+    hdr_row = 3
+    for ci, h in enumerate(["", "Value", "Formula / Notes"], start=1):
+        ws.cell(row=hdr_row, column=ci, value=h)
+    _header_fill(ws, hdr_row, 3)
+
+    # Row 4: total gas-heated customers (weighted)
+    ws.cell(row=4, column=1, value="Gas-heated customers (weighted)")
+    ws.cell(row=4, column=2, value=f"=SUM(per_building!B2:B{last_row})")
+    ws.cell(row=4, column=3, value="SUM of weights (all rows are gas-heated)")
+
+    # Row 5: gas-heated customers that save
+    ws.cell(row=5, column=1, value="Gas-heated customers that save")
+    ws.cell(row=5, column=2, value=f"=SUM(per_building!W2:W{last_row})")
+    ws.cell(row=5, column=3, value="SUM of weighted saves indicator")
+
+    # Row 6: pct save
+    ws.cell(row=6, column=1, value="Percentage that save")
+    ws.cell(row=6, column=2, value="=B5/B4")
+    ws.cell(row=6, column=3, value="weighted_savers / total_weighted")
+    ws.cell(row=6, column=2).number_format = "0.0%"
+
+    # Row 7: pct lose
+    ws.cell(row=7, column=1, value="Percentage that lose")
+    ws.cell(row=7, column=2, value="=1-B6")
+    ws.cell(row=7, column=3, value="1 - pct_save")
+    ws.cell(row=7, column=2).number_format = "0.0%"
+
+    ws.cell(row=9, column=1, value="Headline figure")
+    ws.cell(row=9, column=1).font = Font(bold=True)
+    ws.cell(row=9, column=2, value=scen["headline"])
+
+    for r in (4, 5):
+        ws[f"B{r}"].number_format = "#,##0.00"
+
+    # Bold the headline row
+    if scenario_id == "1-8":
+        ws.cell(row=7, column=1).font = Font(bold=True)
+        ws.cell(row=7, column=2).font = Font(bold=True)
+    else:
+        ws.cell(row=6, column=1).font = Font(bold=True)
+        ws.cell(row=6, column=2).font = Font(bold=True)
+
+    _autosize(ws, {"A": 32, "B": 20, "C": 40})
+    ws.sheet_view.showGridLines = False
+
+
+# ---------------------------------------------------------------------------
+# Validation.
+# ---------------------------------------------------------------------------
+def _validate_kwh_consistency(gas_18: pl.DataFrame, gas_19: pl.DataFrame) -> None:
+    """Assert kWh values are identical between 1-8 and 1-9 DataFrames."""
+    merged = gas_18.select("bldg_id", "annual_kwh_before", "annual_kwh_after").join(
+        gas_19.select(
+            "bldg_id",
+            pl.col("annual_kwh_before").alias("kwh_before_19"),
+            pl.col("annual_kwh_after").alias("kwh_after_19"),
+        ),
+        on="bldg_id",
+        how="inner",
+    )
+    assert merged.height == gas_18.height == gas_19.height, (
+        f"Building count mismatch: 1-8={gas_18.height}, 1-9={gas_19.height}, joined={merged.height}"
+    )
+    before_diff = float((merged["annual_kwh_before"] - merged["kwh_before_19"]).abs().max())  # type: ignore[arg-type]
+    after_diff = float((merged["annual_kwh_after"] - merged["kwh_after_19"]).abs().max())  # type: ignore[arg-type]
+    assert before_diff < 0.01, f"kWh_before differs: max diff = {before_diff}"
+    assert after_diff < 0.01, f"kWh_after differs: max diff = {after_diff}"
+    print(
+        f"  kWh consistency: {merged.height} buildings, "
+        f"before max_diff={before_diff:.2e}, after max_diff={after_diff:.2e}",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Orchestration.
+# ---------------------------------------------------------------------------
+def build_workbook(
+    output_path: Path,
+    scenario_id: str,
+    gas: pl.DataFrame,
+    inputs: dict,
+) -> Path:
+    """Build one workbook for the given scenario."""
+    total_w = float(gas["weight"].sum())
+    save_w = float(gas.filter(pl.col("delta") < 0)["weight"].sum())
+    pct_save = save_w / total_w
+
+    print(f"\n  RIE {scenario_id}:", flush=True)
+    print(f"    gas-heated buildings: {gas.height:,}", flush=True)
+    print(f"    weighted customers: {total_w:,.1f}", flush=True)
+    print(f"    pct save: {pct_save:.4f} ({pct_save * 100:.1f}%)", flush=True)
+    print(f"    pct lose: {1 - pct_save:.4f} ({(1 - pct_save) * 100:.1f}%)", flush=True)
+
+    if scenario_id == "1-8":
+        expected_lose = 0.79
+        actual_lose = 1 - pct_save
+        assert abs(actual_lose - expected_lose) < 0.02, (
+            f"RIE 1-8: expected ~{expected_lose:.0%} lose, got {actual_lose:.1%}"
+        )
+    else:
+        expected_save = 0.87
+        assert abs(pct_save - expected_save) < 0.02, f"RIE 1-9: expected ~{expected_save:.0%} save, got {pct_save:.1%}"
+
+    wb = Workbook()
+    default_ws = wb.active
+    if default_ws is not None:
+        wb.remove(default_ws)
+
+    _write_assumptions(wb, scenario_id, inputs)
+    last_row = _write_per_building(wb, gas)
+    _write_result(wb, last_row, scenario_id)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(str(output_path))
+    print(
+        f"    Wrote {output_path} ({output_path.stat().st_size / 1024:.1f} KB)",
+        flush=True,
+    )
+    return output_path
+
+
+# ---------------------------------------------------------------------------
+# Google Sheets upload.
+# ---------------------------------------------------------------------------
+_TAB_FORMATTING: dict[str, dict] = {
+    "assumptions": {
+        "wrap_columns": ["B:B"],
+        "column_widths_px": {"A": 180, "B": 640},
+        "freeze_rows": 0,
+        "bold_header": False,
+    },
+    "per_building": {
+        "column_number_formats": {
+            "C": "#,##0",
+            "D": "#,##0",
+            "E": '"$"#,##0.00',
+            "F": '"$"#,##0.00',
+            "G": '"$"#,##0.00',
+            "H": '"$"#,##0.00',
+            "I": '"$"#,##0.00',
+            "J": '"$"#,##0.00',
+            "K": '"$"#,##0.00',
+            "L": '"$"#,##0.00',
+            "M": '"$"#,##0.00',
+            "N": '"$"#,##0.00',
+            "O": '"$"#,##0.00',
+            "P": '"$"#,##0.00',
+            "Q": '"$"#,##0.00',
+            "R": '"$"#,##0.00',
+            "S": '"$"#,##0.00',
+            "T": '"$"#,##0.00',
+            "U": '"$"#,##0.00',
+        },
+        "auto_resize_columns": ["A:W"],
+        "freeze_rows": 1,
+        "bold_header": True,
+    },
+    "result": {
+        "auto_resize_columns": ["A:C"],
+        "freeze_rows": 0,
+        "bold_header": True,
+    },
+}
+
+
+def upload_to_sheet(xlsx_path: Path, spreadsheet_id: str) -> None:
+    from lib.data.gsheets import apply_sheet_formatting, xlsx_to_gsheet
+
+    print(f"  Uploading {xlsx_path} -> {spreadsheet_id} ...", flush=True)
+    spreadsheet = xlsx_to_gsheet(xlsx_path, spreadsheet_id, delete_other_tabs=True)
+    for ws in spreadsheet.worksheets():
+        spec = _TAB_FORMATTING.get(ws.title)
+        if spec:
+            apply_sheet_formatting(ws, **spec)
+    print(
+        f"  Done. https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit",
+        flush=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload to Google Sheets after building.",
+    )
+    args = parser.parse_args(argv)
+
+    print("Loading tariff inputs ...", flush=True)
+    inputs = _load_inputs()
+    print(
+        f"  vol_rate = {inputs['default_vol_usd_per_kwh']:.5f}, "
+        f"annual_fixed = ${inputs['annual_fixed_per_customer']:,.2f}",
+        flush=True,
+    )
+
+    print("Loading master bills (run 1+2) ...", flush=True)
+    before = _load_annual_bills(PATH_BILLS_12)
+    print(f"  {before.height:,} annual rows for {UTILITY}", flush=True)
+
+    print("Loading master bills (run 3+4) ...", flush=True)
+    after_default = _load_annual_bills(PATH_BILLS_34)
+    print(f"  {after_default.height:,} rows", flush=True)
+
+    print("Loading master bills (run 19+20) ...", flush=True)
+    after_hprate = _load_annual_bills(PATH_BILLS_1920)
+    print(f"  {after_hprate.height:,} rows", flush=True)
+
+    print("Deriving annual kWh (upgrade 0 from run 1+2, upgrade 2 from run 3+4) ...", flush=True)
+    kwh_before = _derive_annual_kwh(before, inputs)
+    kwh_after = _derive_annual_kwh(after_default, inputs)
+    print(
+        f"  upgrade 0 median: {kwh_before['annual_kwh'].median():,.0f} kWh, "
+        f"upgrade 2 median: {kwh_after['annual_kwh'].median():,.0f} kWh",
+        flush=True,
+    )
+
+    gas_default = _join_and_filter(before, after_default, kwh_before, kwh_after)
+    gas_hprate = _join_and_filter(before, after_hprate, kwh_before, kwh_after)
+
+    _validate_kwh_consistency(gas_default, gas_hprate)
+
+    out_1_8 = build_workbook(Path("cache/rie_1_8.xlsx"), "1-8", gas_default, inputs)
+    out_1_9 = build_workbook(Path("cache/rie_1_9.xlsx"), "1-9", gas_hprate, inputs)
+
+    if args.upload:
+        print("\nUploading ...", flush=True)
+        upload_to_sheet(out_1_8, SPREADSHEET_1_8)
+        upload_to_sheet(out_1_9, SPREADSHEET_1_9)
+
+    return 0
+
+
+def _join_and_filter(
+    before: pl.DataFrame,
+    after: pl.DataFrame,
+    kwh_before: pl.DataFrame,
+    kwh_after: pl.DataFrame,
+) -> pl.DataFrame:
+    """Join before/after on bldg_id, filter to gas-heated, add kWh + LMI totals + delta."""
+    before_r = before.rename({c: f"{c}_before" for c in BILL_COLS}).select(
+        "bldg_id",
+        "weight",
+        "heats_with_natgas",
+        *[f"{c}_before" for c in BILL_COLS],
+    )
+    after_r = after.select(
+        "bldg_id",
+        *[pl.col(c).alias(f"{c}_after") for c in BILL_COLS],
+    )
+    joined = before_r.join(after_r, on="bldg_id", how="inner")
+    joined = joined.join(
+        kwh_before.select("bldg_id", pl.col("annual_kwh").alias("annual_kwh_before")),
+        on="bldg_id",
+        how="left",
+    )
+    joined = joined.join(
+        kwh_after.select("bldg_id", pl.col("annual_kwh").alias("annual_kwh_after")),
+        on="bldg_id",
+        how="left",
+    )
+    gas = joined.filter(pl.col("heats_with_natgas"))
+
+    return gas.with_columns(
+        pl.sum_horizontal([f"{c}_before" for c in LMI_BILL_COLS]).alias("energy_bill_lmi_before"),
+        pl.sum_horizontal([f"{c}_after" for c in LMI_BILL_COLS]).alias("energy_bill_lmi_after"),
+    ).with_columns(
+        (pl.col("energy_bill_lmi_after") - pl.col("energy_bill_lmi_before")).alias("delta"),
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_8_1_9_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_8_1_9_workbook.py
@@ -22,7 +22,6 @@ import sys
 from pathlib import Path
 
 import polars as pl
-import yaml
 from openpyxl import Workbook
 from openpyxl.styles import Alignment, Font, PatternFill
 
@@ -40,9 +39,17 @@ PATH_BILLS_12 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_1+2/comb_bills_ye
 PATH_BILLS_34 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_3+4/comb_bills_year_target/"
 PATH_BILLS_1920 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_19+20/comb_bills_year_target/"
 
+KWH_BATCH = "ri_20260504_kwh_export_v2"
+_KWH_BASE = f"{S3_BASE}/{_state}/rie/{KWH_BATCH}"
+PATH_KWH_U0 = f"{_KWH_BASE}/20260505_011359_ri_rie_run1_up00_precalc__default/billing_kwh_annual.parquet"
+PATH_KWH_U2 = f"{_KWH_BASE}/20260505_011437_ri_rie_run3_up02_default__default/billing_kwh_annual.parquet"
+
 RDP_REF = "e9e5088"
-RDP_REV_YAML_PATH = "rate_design/hp_rates/ri/config/rev_requirement/rie_rate_case_test_year.yaml"
 RDP_TARIFF_DIR = "rate_design/hp_rates/ri/config/tariffs/electric"
+
+FIXED_CHARGE_PER_MONTH = 10.01
+FIXED_CHARGE_PER_YEAR = FIXED_CHARGE_PER_MONTH * 12
+HP_FLAT_COMBINED_RATE = 0.23129
 
 REPORTS2_GITHUB_BASE = "https://github.com/switchbox-data/reports2/blob"
 
@@ -57,7 +64,6 @@ BILL_COLS = [
     "oil_total_bill",
     "propane_total_bill",
 ]
-KWH_COLS = ["elec_delivery_bill", "elec_fixed_charge"]
 LMI_BILL_COLS = [
     "elec_total_bill_lmi_32",
     "gas_total_bill_lmi_32",
@@ -123,7 +129,6 @@ def _load_annual_bills(path: str) -> pl.DataFrame:
             "weight",
             "heats_with_natgas",
             *BILL_COLS,
-            *KWH_COLS,
         )
         .collect()
     )
@@ -131,31 +136,24 @@ def _load_annual_bills(path: str) -> pl.DataFrame:
     return result
 
 
-def _load_inputs() -> dict:
-    """Pull revenue-requirement YAML, tariff rates, and report tariff-table values."""
-    import pickle
+def _load_billing_kwh(path: str) -> pl.DataFrame:
+    """Load exported billing kWh (annual grid-consumed electricity)."""
+    return pl.read_parquet(path).select("bldg_id", "annual_kwh_grid")
 
-    raw_yaml = fetch_rdp_file(RDP_REV_YAML_PATH, RDP_REF)
-    rev = yaml.safe_load(raw_yaml)
-    total_rr = float(rev["total_delivery_revenue_requirement"])
-    n_customers = float(rev["test_year_customer_count"])
-    ty_kwh = float(rev["test_year_residential_kwh"])
+
+def _load_inputs() -> dict:
+    """Pull tariff rates and report tariff-table values."""
+    import pickle
 
     def _fetch_tariff(filename: str) -> dict:
         return parse_urdb_json(fetch_rdp_file(f"{RDP_TARIFF_DIR}/{filename}", RDP_REF))
 
-    default_del = _fetch_tariff("rie_default_calibrated.json")
     hp_flat_del = _fetch_tariff("rie_hp_flat_calibrated.json")
     hp_flat_sup = _fetch_tariff("rie_hp_flat_supply_calibrated.json")
-
-    default_vol = float(default_del["items"][0]["energyratestructure"][0][0]["rate"])
-    annual_fixed_per_customer = (total_rr - default_vol * ty_kwh) / n_customers
 
     rv = pickle.loads(Path("cache/report_variables.pkl").read_bytes())
 
     return {
-        "default_vol_usd_per_kwh": default_vol,
-        "annual_fixed_per_customer": annual_fixed_per_customer,
         "tariff_table": {
             "elec_customer_charge": rv["elec_customer_charge"],
             "elec_other_fixed_charges": rv["elec_other_fixed_charges"],
@@ -167,20 +165,12 @@ def _load_inputs() -> dict:
             "gas_nonheating_fixed_charge": rv["gas_nonheating_fixed_charge"],
             "gas_avg_per_therm": rv["gas_avg_per_therm"],
             "gas_nonheating_avg_per_therm": rv["gas_nonheating_avg_per_therm"],
+            "oil_price_range": rv.get("oil_price_range", "$3.48–$4.10 /gal (monthly prices)"),  # noqa: RUF001
+            "propane_price_range": rv.get("propane_price_range", "$3.44–$3.67 /gal (monthly prices)"),  # noqa: RUF001
             "hp_flat_delivery_cents": float(hp_flat_del["items"][0]["energyratestructure"][0][0]["rate"]) * 100,
             "hp_flat_supply_cents": float(hp_flat_sup["items"][0]["energyratestructure"][0][0]["rate"]) * 100,
         },
     }
-
-
-def _derive_annual_kwh(bills: pl.DataFrame, inputs: dict) -> pl.DataFrame:
-    """Add annual_kwh column derived from the delivery bill components."""
-    return bills.with_columns(
-        (
-            (pl.col("elec_fixed_charge") + pl.col("elec_delivery_bill") - inputs["annual_fixed_per_customer"])
-            / inputs["default_vol_usd_per_kwh"]
-        ).alias("annual_kwh")
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -374,12 +364,92 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
         row += 1
 
+    # --- How bills are computed -----------------------------------------------
+    row += 1
+    ws.cell(row=row, column=1, value="How bills are computed")
+    ws.cell(row=row, column=1).font = Font(bold=True)
+    row += 1
+
+    how_rows: list[tuple[str, str]] = [
+        (
+            "Fixed charge",
+            f"${FIXED_CHARGE_PER_MONTH:.2f}/mo (${FIXED_CHARGE_PER_YEAR:.2f}/yr): "
+            "$6.00 customer charge + $3.22 RE Growth + $0.79 LIHEAP Enhancement. "
+            "Matches fixedchargefirstmeter in all calibrated tariff JSONs and the testimony.",
+        ),
+        (
+            "kWh source",
+            "Exported directly from CAIRO's billing pipeline (billing_kwh_annual.parquet). "
+            "These are grid-consumed kWh after PV clipping (max(electricity_net, 0)), "
+            "kwh_scale_factor application (0.9568), and 48-hour day-of-week timeshift. "
+            "Upgrade 0 = before HP, upgrade 2 = after HP.",
+        ),
+        (
+            "Electric bills",
+            "From CAIRO's hourly simulation (elec_total_bill). "
+            "CAIRO applies each hour's consumption to the applicable tariff rate and sums to the annual total.",
+        ),
+    ]
+    for label, value in how_rows:
+        ws.cell(row=row, column=1, value=label)
+        ws.cell(row=row, column=2, value=value)
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+    # --- Seasonal rate explanation for 1-8 ------------------------------------
+    if scenario_id == "1-8":
+        row += 1
+        ws.cell(row=row, column=1, value="Why no bill-verification formula (RIE 1-8)")
+        ws.cell(row=row, column=1).font = Font(bold=True)
+        row += 1
+        seasonal_text = (
+            "The default supply tariff (rie_default_supply_calibrated.json) uses three seasonal rates:\n"
+            " - Winter (Jan, Feb, Mar, Nov, Dec): 31.38 ¢/kWh\n"
+            " - Summer (Jun, Jul, Aug, Sep): 24.78 ¢/kWh\n"
+            " - Shoulder (Apr, May, Oct): 29.49 ¢/kWh\n\n"
+            "These rates bundle delivery + supply. Because each building has a different monthly "
+            "consumption profile, a single annual_kwh × rate formula cannot reproduce the bill — "  # noqa: RUF001
+            "it would require 12 monthly kWh values and per-month rate assignments. "
+            "CAIRO computes bills hourly (8,760 hours), applying the correct seasonal rate to each "
+            "hour's consumption, then sums to the annual total.\n\n"
+            "The elec_total_bill column is the exact annual bill from CAIRO. "
+            "To verify it independently, one would need the building's hourly load profile "
+            "(available in billing_kwh_8760.parquet) and the seasonal rate schedule above.\n\n"
+            "For RIE 1-9, the HP flat tariff uses a single year-round rate (23.13 ¢/kWh), so "
+            "annual_kwh × 0.23129 + 10.01 × 12 reproduces the bill within ~$1."  # noqa: RUF001
+        )
+        ws.cell(row=row, column=1, value=seasonal_text)
+        ws.cell(row=row, column=1).alignment = Alignment(wrap_text=True)
+        ws.merge_cells(start_row=row, start_column=1, end_row=row, end_column=3)
+        row += 1
+
+    # --- Bill verification formula for 1-9 ------------------------------------
+    if scenario_id == "1-9":
+        row += 1
+        ws.cell(row=row, column=1, value="Bill-verification formula (RIE 1-9)")
+        ws.cell(row=row, column=1).font = Font(bold=True)
+        row += 1
+        verify_text = (
+            f"The HP flat supply tariff (rie_hp_flat_supply_calibrated.json) uses a single flat rate "
+            f"of {HP_FLAT_COMBINED_RATE * 100:.2f} ¢/kWh (delivery + supply bundled). The verification formula is:\n\n"
+            f"  elec_bill_formula = annual_kwh_after × {HP_FLAT_COMBINED_RATE} + {FIXED_CHARGE_PER_MONTH} × 12\n\n"  # noqa: RUF001
+            "The elec_bill_residual column shows elec_bill_after - elec_bill_formula. "
+            "Residuals of ~$1 are expected due to CAIRO's hourly billing mechanics "
+            "(48-hour day-of-week timeshift aligning 2018 weather year to 2025)."
+        )
+        ws.cell(row=row, column=1, value=verify_text)
+        ws.cell(row=row, column=1).alignment = Alignment(wrap_text=True)
+        ws.merge_cells(start_row=row, start_column=1, end_row=row, end_column=3)
+        row += 1
+
     # --- Data sources -------------------------------------------------------
     row += 1
     ds_rows: list[tuple[str, str]] = [
         ("Data sources", ""),
         ("Before bills", f"{scen['before_desc']}\n{scen['before_path']}"),
         ("After bills", f"{scen['after_desc']}\n{scen['after_path']}"),
+        ("kWh (upgrade 0)", f"billing_kwh_annual.parquet from\n{PATH_KWH_U0}"),
+        ("kWh (upgrade 2)", f"billing_kwh_annual.parquet from\n{PATH_KWH_U2}"),
         (
             "Analysis notebook",
             _reports2_permalink("reports/ri_hp_rates/notebooks/analysis.qmd"),
@@ -402,14 +472,13 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         (
             "annual_kwh_before",
             "Annual grid-consumed electricity (kWh), upgrade 0 (current HVAC). "
-            "Derived from delivery bill: (bill_delivery - annual_fixed_per_customer) / vol_rate. "
-            "Same derivation as RIE 1-5 workbook.",
+            "Exported from CAIRO billing pipeline (billing_kwh_annual.parquet). "
+            "Reflects PV clipping, kwh_scale_factor (0.9568), and 48-hour timeshift.",
         ),
         (
             "annual_kwh_after",
             "Annual grid-consumed electricity (kWh), upgrade 2 (heat pump). "
-            "Derived from run 3+4 delivery bills (default rate); "
-            "same physical consumption regardless of which tariff is applied.",
+            "Same source as above; same physical consumption regardless of tariff.",
         ),
         ("elec_bill_before", "Annual electric bill before HP, undiscounted"),
         (
@@ -440,6 +509,23 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         ("saves", "Formula: 1 if delta < 0, else 0"),
         ("w_saves", "Formula: weight * saves (weighted savings indicator)"),
     ]
+
+    # Add 1-9-specific formula columns
+    if scenario_id == "1-9":
+        col_rows.extend(
+            [
+                (
+                    "elec_bill_formula",
+                    f"Formula: annual_kwh_after × {HP_FLAT_COMBINED_RATE} + {FIXED_CHARGE_PER_MONTH} × 12. "  # noqa: RUF001
+                    "Verification of the CAIRO electric bill using the HP flat combined rate.",
+                ),
+                (
+                    "elec_bill_residual",
+                    "Formula: elec_bill_after - elec_bill_formula. Expected ~$1 from CAIRO's hourly billing mechanics.",
+                ),
+            ]
+        )
+
     for label, value in col_rows:
         ws.cell(row=row, column=1, value=label)
         if label in bold_labels:
@@ -452,7 +538,7 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
     ws.sheet_view.showGridLines = False
 
 
-def _write_per_building(wb: Workbook, gas: pl.DataFrame) -> int:
+def _write_per_building(wb: Workbook, gas: pl.DataFrame, scenario_id: str) -> int:
     """Write per-building bills sheet. Returns the last data row number."""
     ws = wb.create_sheet("per_building")
 
@@ -481,6 +567,14 @@ def _write_per_building(wb: Workbook, gas: pl.DataFrame) -> int:
         "saves",  # V  formula
         "w_saves",  # W  formula
     ]
+    if scenario_id == "1-9":
+        headers.extend(
+            [
+                "elec_bill_formula",  # X  formula (1-9 only)
+                "elec_bill_residual",  # Y  formula (1-9 only)
+            ]
+        )
+
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
     ws.freeze_panes = "A2"
@@ -523,6 +617,12 @@ def _write_per_building(wb: Workbook, gas: pl.DataFrame) -> int:
         # W: w_saves = weight * saves
         ws.cell(row=i, column=23, value=f"=B{i}*V{i}")
 
+        if scenario_id == "1-9":
+            # X: elec_bill_formula = annual_kwh_after * rate + fixed * 12
+            ws.cell(row=i, column=24, value=f"=D{i}*{HP_FLAT_COMBINED_RATE}+{FIXED_CHARGE_PER_MONTH}*12")
+            # Y: elec_bill_residual = elec_bill_after - elec_bill_formula
+            ws.cell(row=i, column=25, value=f"=K{i}-X{i}")
+
     last_row = 1 + len(rows)
 
     for r in range(2, last_row + 1):
@@ -530,35 +630,39 @@ def _write_per_building(wb: Workbook, gas: pl.DataFrame) -> int:
             ws[f"{col}{r}"].number_format = "#,##0"
         for col in "EFGHIJKLMNOPQRSTU":
             ws[f"{col}{r}"].number_format = '"$"#,##0.00'
+        if scenario_id == "1-9":
+            ws[f"X{r}"].number_format = '"$"#,##0.00'
+            ws[f"Y{r}"].number_format = '"$"#,##0.00'
 
-    _autosize(
-        ws,
-        {
-            "A": 10,
-            "B": 10,
-            "C": 18,
-            "D": 18,
-            "E": 16,
-            "F": 18,
-            "G": 16,
-            "H": 18,
-            "I": 14,
-            "J": 16,
-            "K": 16,
-            "L": 18,
-            "M": 16,
-            "N": 18,
-            "O": 14,
-            "P": 16,
-            "Q": 22,
-            "R": 22,
-            "S": 22,
-            "T": 22,
-            "U": 14,
-            "V": 8,
-            "W": 12,
-        },
-    )
+    widths: dict[str, int] = {
+        "A": 10,
+        "B": 10,
+        "C": 18,
+        "D": 18,
+        "E": 16,
+        "F": 18,
+        "G": 16,
+        "H": 18,
+        "I": 14,
+        "J": 16,
+        "K": 16,
+        "L": 18,
+        "M": 16,
+        "N": 18,
+        "O": 14,
+        "P": 16,
+        "Q": 22,
+        "R": 22,
+        "S": 22,
+        "T": 22,
+        "U": 14,
+        "V": 8,
+        "W": 12,
+    }
+    if scenario_id == "1-9":
+        widths["X"] = 18
+        widths["Y"] = 18
+    _autosize(ws, widths)
     return last_row
 
 
@@ -681,7 +785,7 @@ def build_workbook(
         wb.remove(default_ws)
 
     _write_assumptions(wb, scenario_id, inputs)
-    last_row = _write_per_building(wb, gas)
+    last_row = _write_per_building(wb, gas, scenario_id)
     _write_result(wb, last_row, scenario_id)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -696,54 +800,62 @@ def build_workbook(
 # ---------------------------------------------------------------------------
 # Google Sheets upload.
 # ---------------------------------------------------------------------------
-_TAB_FORMATTING: dict[str, dict] = {
-    "assumptions": {
-        "wrap_columns": ["B:B"],
-        "column_widths_px": {"A": 180, "B": 640},
-        "freeze_rows": 0,
-        "bold_header": False,
-    },
-    "per_building": {
-        "column_number_formats": {
-            "C": "#,##0",
-            "D": "#,##0",
-            "E": '"$"#,##0.00',
-            "F": '"$"#,##0.00',
-            "G": '"$"#,##0.00',
-            "H": '"$"#,##0.00',
-            "I": '"$"#,##0.00',
-            "J": '"$"#,##0.00',
-            "K": '"$"#,##0.00',
-            "L": '"$"#,##0.00',
-            "M": '"$"#,##0.00',
-            "N": '"$"#,##0.00',
-            "O": '"$"#,##0.00',
-            "P": '"$"#,##0.00',
-            "Q": '"$"#,##0.00',
-            "R": '"$"#,##0.00',
-            "S": '"$"#,##0.00',
-            "T": '"$"#,##0.00',
-            "U": '"$"#,##0.00',
+def _tab_formatting(scenario_id: str) -> dict[str, dict]:
+    number_formats = {
+        "C": "#,##0",
+        "D": "#,##0",
+        "E": '"$"#,##0.00',
+        "F": '"$"#,##0.00',
+        "G": '"$"#,##0.00',
+        "H": '"$"#,##0.00',
+        "I": '"$"#,##0.00',
+        "J": '"$"#,##0.00',
+        "K": '"$"#,##0.00',
+        "L": '"$"#,##0.00',
+        "M": '"$"#,##0.00',
+        "N": '"$"#,##0.00',
+        "O": '"$"#,##0.00',
+        "P": '"$"#,##0.00',
+        "Q": '"$"#,##0.00',
+        "R": '"$"#,##0.00',
+        "S": '"$"#,##0.00',
+        "T": '"$"#,##0.00',
+        "U": '"$"#,##0.00',
+    }
+    auto_range = "A:W"
+    if scenario_id == "1-9":
+        number_formats["X"] = '"$"#,##0.00'
+        number_formats["Y"] = '"$"#,##0.00'
+        auto_range = "A:Y"
+    return {
+        "assumptions": {
+            "wrap_columns": ["B:B"],
+            "column_widths_px": {"A": 180, "B": 640},
+            "freeze_rows": 0,
+            "bold_header": False,
         },
-        "auto_resize_columns": ["A:W"],
-        "freeze_rows": 1,
-        "bold_header": True,
-    },
-    "result": {
-        "auto_resize_columns": ["A:C"],
-        "freeze_rows": 0,
-        "bold_header": True,
-    },
-}
+        "per_building": {
+            "column_number_formats": number_formats,
+            "auto_resize_columns": [auto_range],
+            "freeze_rows": 1,
+            "bold_header": True,
+        },
+        "result": {
+            "auto_resize_columns": ["A:C"],
+            "freeze_rows": 0,
+            "bold_header": True,
+        },
+    }
 
 
-def upload_to_sheet(xlsx_path: Path, spreadsheet_id: str) -> None:
+def upload_to_sheet(xlsx_path: Path, spreadsheet_id: str, scenario_id: str) -> None:
     from lib.data.gsheets import apply_sheet_formatting, xlsx_to_gsheet
 
     print(f"  Uploading {xlsx_path} -> {spreadsheet_id} ...", flush=True)
     spreadsheet = xlsx_to_gsheet(xlsx_path, spreadsheet_id, delete_other_tabs=True)
+    tab_fmt = _tab_formatting(scenario_id)
     for ws in spreadsheet.worksheets():
-        spec = _TAB_FORMATTING.get(ws.title)
+        spec = tab_fmt.get(ws.title)
         if spec:
             apply_sheet_formatting(ws, **spec)
     print(
@@ -766,9 +878,16 @@ def main(argv: list[str] | None = None) -> int:
 
     print("Loading tariff inputs ...", flush=True)
     inputs = _load_inputs()
+    print(f"  fixed_charge = ${FIXED_CHARGE_PER_MONTH:.2f}/mo (${FIXED_CHARGE_PER_YEAR:.2f}/yr)", flush=True)
+
+    print("Loading billing kWh (upgrade 0 from run-1, upgrade 2 from run-3) ...", flush=True)
+    kwh_before = _load_billing_kwh(PATH_KWH_U0)
+    kwh_after = _load_billing_kwh(PATH_KWH_U2)
     print(
-        f"  vol_rate = {inputs['default_vol_usd_per_kwh']:.5f}, "
-        f"annual_fixed = ${inputs['annual_fixed_per_customer']:,.2f}",
+        f"  upgrade 0: {kwh_before.height:,} buildings, "
+        f"median {kwh_before['annual_kwh_grid'].median():,.0f} kWh\n"
+        f"  upgrade 2: {kwh_after.height:,} buildings, "
+        f"median {kwh_after['annual_kwh_grid'].median():,.0f} kWh",
         flush=True,
     )
 
@@ -784,15 +903,6 @@ def main(argv: list[str] | None = None) -> int:
     after_hprate = _load_annual_bills(PATH_BILLS_1920)
     print(f"  {after_hprate.height:,} rows", flush=True)
 
-    print("Deriving annual kWh (upgrade 0 from run 1+2, upgrade 2 from run 3+4) ...", flush=True)
-    kwh_before = _derive_annual_kwh(before, inputs)
-    kwh_after = _derive_annual_kwh(after_default, inputs)
-    print(
-        f"  upgrade 0 median: {kwh_before['annual_kwh'].median():,.0f} kWh, "
-        f"upgrade 2 median: {kwh_after['annual_kwh'].median():,.0f} kWh",
-        flush=True,
-    )
-
     gas_default = _join_and_filter(before, after_default, kwh_before, kwh_after)
     gas_hprate = _join_and_filter(before, after_hprate, kwh_before, kwh_after)
 
@@ -803,8 +913,8 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.upload:
         print("\nUploading ...", flush=True)
-        upload_to_sheet(out_1_8, SPREADSHEET_1_8)
-        upload_to_sheet(out_1_9, SPREADSHEET_1_9)
+        upload_to_sheet(out_1_8, SPREADSHEET_1_8, "1-8")
+        upload_to_sheet(out_1_9, SPREADSHEET_1_9, "1-9")
 
     return 0
 
@@ -828,12 +938,12 @@ def _join_and_filter(
     )
     joined = before_r.join(after_r, on="bldg_id", how="inner")
     joined = joined.join(
-        kwh_before.select("bldg_id", pl.col("annual_kwh").alias("annual_kwh_before")),
+        kwh_before.select("bldg_id", pl.col("annual_kwh_grid").alias("annual_kwh_before")),
         on="bldg_id",
         how="left",
     )
     joined = joined.join(
-        kwh_after.select("bldg_id", pl.col("annual_kwh").alias("annual_kwh_after")),
+        kwh_after.select("bldg_id", pl.col("annual_kwh_grid").alias("annual_kwh_after")),
         on="bldg_id",
         how="left",
     )

--- a/reports/ri_hp_rates/testimony_response/build_RIE_1_8_1_9_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_RIE_1_8_1_9_workbook.py
@@ -8,6 +8,12 @@ money after switching to heat pumps."
 
 Both percentages use LMI-adjusted bills (32% enrollment tier).
 
+Each workbook has four sheets:
+  - assumptions: tariff tables, data sources, column descriptions
+  - monthly: 12 rows per building -- consumption x rate = bill derivation (no LMI)
+  - annual: 1 row per building — SUM of monthly + LMI bills + delta/saves
+  - result: headline percentage from annual sheet
+
 Run from the report directory::
 
     uv run python -m testimony_response.build_RIE_1_8_1_9_workbook
@@ -17,6 +23,7 @@ Run from the report directory::
 from __future__ import annotations
 
 import argparse
+import datetime
 import subprocess
 import sys
 from pathlib import Path
@@ -41,29 +48,99 @@ PATH_BILLS_1920 = f"{S3_BASE}/{_state}/all_utilities/{BATCH}/run_19+20/comb_bill
 
 KWH_BATCH = "ri_20260504_kwh_export_v2"
 _KWH_BASE = f"{S3_BASE}/{_state}/rie/{KWH_BATCH}"
-PATH_KWH_U0 = f"{_KWH_BASE}/20260505_011359_ri_rie_run1_up00_precalc__default/billing_kwh_annual.parquet"
-PATH_KWH_U2 = f"{_KWH_BASE}/20260505_011437_ri_rie_run3_up02_default__default/billing_kwh_annual.parquet"
+PATH_KWH_8760_U0 = f"{_KWH_BASE}/20260505_011359_ri_rie_run1_up00_precalc__default/billing_kwh_8760.parquet"
+PATH_KWH_8760_U2 = f"{_KWH_BASE}/20260505_011437_ri_rie_run3_up02_default__default/billing_kwh_8760.parquet"
+
+RESSTOCK_RELEASE = "s3://data.sb/nrel/resstock/res_2024_amy2018_2"
+GAS_CONSUMPTION_COL = "out.natural_gas.total.energy_consumption"
 
 RDP_REF = "e9e5088"
 RDP_TARIFF_DIR = "rate_design/hp_rates/ri/config/tariffs/electric"
-
-FIXED_CHARGE_PER_MONTH = 10.01
-FIXED_CHARGE_PER_YEAR = FIXED_CHARGE_PER_MONTH * 12
-HP_FLAT_COMBINED_RATE = 0.23129
 
 REPORTS2_GITHUB_BASE = "https://github.com/switchbox-data/reports2/blob"
 
 SPREADSHEET_1_8 = "1TEURpTKhM3ddpPagNxq1bT0oB24RyoorD4y7EVfFeUY"
 SPREADSHEET_1_9 = "1wocSf02gT7WS9G_vxs70d1SG1IOwhPLcUZGRuHXDRB8"
 
-BILL_COLS = [
-    "elec_total_bill",
-    "elec_total_bill_lmi_32",
-    "gas_total_bill",
-    "gas_total_bill_lmi_32",
-    "oil_total_bill",
-    "propane_total_bill",
-]
+# ---------------------------------------------------------------------------
+# Tariff rates.
+# ---------------------------------------------------------------------------
+ELEC_DELIVERY_RATE = 0.14058  # $/kWh, flat all months
+ELEC_FIXED_PER_MONTH = 10.01  # $6.00 customer + $3.22 RE Growth + $0.79 LIHEAP
+
+# Default supply rates (LRS seasonal, $/kWh)
+_ELEC_SUPPLY_WINTER = 0.17254  # Jan-Mar
+_ELEC_SUPPLY_SUMMER = 0.10674  # Apr-Sep
+_ELEC_SUPPLY_FALL = 0.15376  # Oct-Dec
+
+ELEC_SUPPLY_DEFAULT: dict[str, float] = {
+    "Jan": _ELEC_SUPPLY_WINTER,
+    "Feb": _ELEC_SUPPLY_WINTER,
+    "Mar": _ELEC_SUPPLY_WINTER,
+    "Apr": _ELEC_SUPPLY_SUMMER,
+    "May": _ELEC_SUPPLY_SUMMER,
+    "Jun": _ELEC_SUPPLY_SUMMER,
+    "Jul": _ELEC_SUPPLY_SUMMER,
+    "Aug": _ELEC_SUPPLY_SUMMER,
+    "Sep": _ELEC_SUPPLY_SUMMER,
+    "Oct": _ELEC_SUPPLY_FALL,
+    "Nov": _ELEC_SUPPLY_FALL,
+    "Dec": _ELEC_SUPPLY_FALL,
+}
+ELEC_COMBINED_DEFAULT: dict[str, float] = {m: ELEC_DELIVERY_RATE + s for m, s in ELEC_SUPPLY_DEFAULT.items()}
+
+HP_FLAT_COMBINED_RATE = 0.23129  # $/kWh, delivery+supply bundled, all months
+
+# Gas tariff rates in $/therm (URDB $/kWh x 29.3)
+KWH_PER_THERM = 29.3
+GAS_FIXED_PER_MONTH = 14.79
+
+# Rate 12 — Residential Heating (before HP)
+_GAS_HEAT_KWH = {
+    "Jan": 0.063686,
+    "Feb": 0.063686,
+    "Mar": 0.063686,
+    "Apr": 0.065945,
+    "May": 0.063843,
+    "Jun": 0.063843,
+    "Jul": 0.063843,
+    "Aug": 0.063843,
+    "Sep": 0.063843,
+    "Oct": 0.063843,
+    "Nov": 0.058560,
+    "Dec": 0.058560,
+}
+GAS_HEATING_PER_THERM: dict[str, float] = {m: r * KWH_PER_THERM for m, r in _GAS_HEAT_KWH.items()}
+
+# Rate 10 — Residential Non-Heating (after HP)
+_GAS_NONHEAT_KWH = {
+    "Jan": 0.059563,
+    "Feb": 0.059563,
+    "Mar": 0.059563,
+    "Apr": 0.061823,
+    "May": 0.061823,
+    "Jun": 0.061823,
+    "Jul": 0.061823,
+    "Aug": 0.061823,
+    "Sep": 0.061823,
+    "Oct": 0.061823,
+    "Nov": 0.049116,
+    "Dec": 0.049116,
+}
+GAS_NONHEATING_PER_THERM: dict[str, float] = {m: r * KWH_PER_THERM for m, r in _GAS_NONHEAT_KWH.items()}
+
+MONTH_ORDER = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+MONTH_INT_TO_STR: dict[int, str] = {i + 1: m for i, m in enumerate(MONTH_ORDER)}
+
+# Build hour→month mapping for 2018 (AMY weather year).
+_HOUR_TO_MONTH: list[int] = []
+for _m in range(1, 13):
+    _start = datetime.datetime(2018, _m, 1)
+    _end = datetime.datetime(2018, _m + 1, 1) if _m < 12 else datetime.datetime(2019, 1, 1)
+    _HOUR_TO_MONTH.extend([_m] * int((_end - _start).total_seconds() // 3600))
+assert len(_HOUR_TO_MONTH) == 8760
+
+# Bills columns used from master bills.
 LMI_BILL_COLS = [
     "elec_total_bill_lmi_32",
     "gas_total_bill_lmi_32",
@@ -71,7 +148,6 @@ LMI_BILL_COLS = [
     "propane_total_bill",
 ]
 
-# Scenario descriptions for the assumptions sheet.
 SCENARIOS: dict[str, dict[str, str]] = {
     "1-8": {
         "request": (
@@ -119,26 +195,65 @@ def _reports2_permalink(rel_path: str) -> str:
 # ---------------------------------------------------------------------------
 # Data loading.
 # ---------------------------------------------------------------------------
-def _load_annual_bills(path: str) -> pl.DataFrame:
-    """Load annual master bills for RIE, selecting only needed columns."""
-    lf = pl.scan_parquet(path, hive_partitioning=True)
-    result = (
-        lf.filter((pl.col("sb.electric_utility") == UTILITY) & (pl.col("month") == "Annual"))
+def _load_monthly_elec_kwh(path_8760: str) -> pl.DataFrame:
+    """Load 8760 billing kWh and roll to monthly."""
+    hour_map = pl.DataFrame(
+        {
+            "hour": list(range(8760)),
+            "month_int": _HOUR_TO_MONTH,
+        }
+    ).with_columns(pl.col("hour").cast(pl.Int16))
+
+    return (
+        pl.scan_parquet(path_8760)
+        .join(hour_map.lazy(), on="hour")
+        .group_by("bldg_id", "month_int")
+        .agg(pl.col("grid_cons_kwh").sum().alias("elec_kwh"))
+        .sort("bldg_id", "month_int")
+        .with_columns(pl.col("month_int").replace_strict(MONTH_INT_TO_STR, return_dtype=pl.String).alias("month"))
+        .select("bldg_id", "month", "elec_kwh")
+        .collect()  # ty: ignore[invalid-return-type]
+    )
+
+
+def _load_monthly_gas_kwh(bldg_ids: list[int], upgrade: str) -> pl.DataFrame:
+    """Load ResStock monthly gas consumption for specific buildings."""
+    upgrade_int = str(int(upgrade))
+    base = f"{RESSTOCK_RELEASE}/load_curve_monthly/state=RI/upgrade={upgrade}"
+    paths = [f"{base}/{bid}-{upgrade_int}.parquet" for bid in bldg_ids]
+    return (
+        pl.scan_parquet(paths)
+        .select(
+            "bldg_id",
+            pl.col("month").cast(pl.Int8).alias("month_int"),
+            pl.col(GAS_CONSUMPTION_COL).fill_null(0.0).alias("gas_kwh"),
+        )
+        .sort("bldg_id", "month_int")
+        .with_columns(pl.col("month_int").replace_strict(MONTH_INT_TO_STR, return_dtype=pl.String).alias("month"))
+        .select("bldg_id", "month", "gas_kwh")
+        .collect()  # ty: ignore[invalid-return-type]
+    )
+
+
+def _load_bills(path: str) -> pl.DataFrame:
+    """Load master bills (all months including Annual) for RIE."""
+    return (
+        pl.scan_parquet(path, hive_partitioning=True)
+        .filter(pl.col("sb.electric_utility") == UTILITY)
         .select(
             "bldg_id",
             "weight",
             "heats_with_natgas",
-            *BILL_COLS,
+            "month",
+            "elec_total_bill",
+            "elec_total_bill_lmi_32",
+            "gas_total_bill",
+            "gas_total_bill_lmi_32",
+            "oil_total_bill",
+            "propane_total_bill",
         )
-        .collect()
+        .collect()  # ty: ignore[invalid-return-type]
     )
-    assert isinstance(result, pl.DataFrame)
-    return result
-
-
-def _load_billing_kwh(path: str) -> pl.DataFrame:
-    """Load exported billing kWh (annual grid-consumed electricity)."""
-    return pl.read_parquet(path).select("bldg_id", "annual_kwh_grid")
 
 
 def _load_inputs() -> dict:
@@ -202,14 +317,13 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
 
     row = 3
 
-    # --- Key-value rows (2 columns) ----------------------------------------
     kv_rows: list[tuple[str, str]] = [
         ("Discovery request", scen["request"]),
         ("", ""),
         ("Assumptions", ""),
         (
             "LMI discount tier",
-            "32% enrollment (RI's current rate). The _lmi_32 bill columns "
+            "32% of eligible households are enrolled and receive discount. The _lmi_32 bill columns "
             "apply existing utility LMI discounts to enrolled low-income "
             "households. Non-enrolled households see the undiscounted bill.",
         ),
@@ -230,7 +344,7 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
             "delta > 0 (annual LMI-adjusted energy bill increases after HP)",
         ),
     ]
-    bold_labels = {"Assumptions", "Data sources", "per_building columns"}
+    bold_labels = {"Assumptions", "Data sources", "monthly columns", "annual columns"}
     for label, value in kv_rows:
         ws.cell(row=row, column=1, value=label)
         if label in bold_labels:
@@ -239,7 +353,7 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
         row += 1
 
-    # --- Tariff table (3 columns) -------------------------------------------
+    # --- Default tariff table ------------------------------------------------
     row += 1
     ws.cell(row=row, column=1, value="Default tariffs (before)")
     ws.cell(row=row, column=1).font = Font(bold=True)
@@ -254,45 +368,21 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
     row += 1
 
     default_tariff_rows: list[tuple[str, str, str]] = [
-        (
-            "Electricity — customer charge (A-16)",
-            f"${tt['elec_customer_charge']:.2f} /mo",
-            "—",
-        ),
-        (
-            "Electricity — RE Growth + LIHEAP (A-16)",
-            f"${tt['elec_other_fixed_charges']:.2f} /mo",
-            "—",
-        ),
-        (
-            "Electricity — delivery (A-16)",
-            "—",
-            f"{tt['elec_delivery_avg_cents']:.2f} ¢/kWh",
-        ),
-        (
-            "Electricity — supply, winter (LRS, Jan–Mar)",  # noqa: RUF001
-            "—",
-            f"{tt['elec_lrs_winter_cents']:.2f} ¢/kWh",
-        ),
-        (
-            "Electricity — supply, summer (LRS, Apr–Sep)",  # noqa: RUF001
-            "—",
-            f"{tt['elec_lrs_summer_cents']:.2f} ¢/kWh",
-        ),
-        (
-            "Electricity — supply, fall (LRS, Oct–Dec)",  # noqa: RUF001
-            "—",
-            f"{tt['elec_lrs_fall_cents']:.2f} ¢/kWh",
-        ),
+        ("Electricity — customer charge (A-16)", f"${tt['elec_customer_charge']:.2f} /mo", "—"),
+        ("Electricity — RE Growth + LIHEAP (A-16)", f"${tt['elec_other_fixed_charges']:.2f} /mo", "—"),
+        ("Electricity — delivery (A-16)", "—", f"{tt['elec_delivery_avg_cents']:.2f} ¢/kWh"),
+        ("Electricity — supply, winter (LRS, Jan–Mar)", "—", f"{tt['elec_lrs_winter_cents']:.2f} ¢/kWh"),  # noqa: RUF001
+        ("Electricity — supply, summer (LRS, Apr–Sep)", "—", f"{tt['elec_lrs_summer_cents']:.2f} ¢/kWh"),  # noqa: RUF001
+        ("Electricity — supply, fall (LRS, Oct–Dec)", "—", f"{tt['elec_lrs_fall_cents']:.2f} ¢/kWh"),  # noqa: RUF001
         (
             "Natural gas — Rate 12 (heating)",
             f"${tt['gas_fixed_charge']:.2f} /mo",
-            f"${tt['gas_avg_per_therm']:.3f} /therm",
+            f"${tt['gas_avg_per_therm']:.3f} /therm (avg)",
         ),
         (
             "Natural gas — Rate 10 (non-heating)",
             f"${tt['gas_nonheating_fixed_charge']:.2f} /mo",
-            f"${tt['gas_nonheating_avg_per_therm']:.3f} /therm",
+            f"${tt['gas_nonheating_avg_per_therm']:.3f} /therm (avg)",
         ),
         ("Heating oil (EIA)", "—", "$3.48–$4.10 /gal (monthly prices)"),  # noqa: RUF001
         ("Propane (EIA)", "—", "$3.44–$3.67 /gal (monthly prices)"),  # noqa: RUF001
@@ -312,42 +402,22 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
             row=row,
             column=2,
             value=(
-                "Delivery: EPMC allocation (revenue target reflects HP subclass cost-of-service). "
-                "Supply: per-customer allocation (each customer bears an equal share of supply revenue). "
-                "Gas, oil, and propane tariffs unchanged."
+                "Delivery: EPMC allocation. Supply: per-customer allocation. Gas, oil, and propane tariffs unchanged."
             ),
         )
         ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
         row += 1
-
         _header_fill(ws, row, 3)
         for c, hdr in enumerate(["Tariff", "Fixed charge", "Volumetric rate"], 1):
             ws.cell(row=row, column=c, value=hdr)
         row += 1
-
-        hp_tariff_rows: list[tuple[str, str, str]] = [
-            (
-                "Electricity — customer charge",
-                f"${tt['elec_customer_charge']:.2f} /mo",
-                "—",
-            ),
-            (
-                "Electricity — RE Growth + LIHEAP",
-                f"${tt['elec_other_fixed_charges']:.2f} /mo",
-                "—",
-            ),
-            (
-                "Electricity — HP delivery (EPMC)",
-                "—",
-                f"{tt['hp_flat_delivery_cents']:.2f} ¢/kWh",
-            ),
-            (
-                "Electricity — HP supply (per-customer)",
-                "—",
-                f"{tt['hp_flat_supply_cents']:.2f} ¢/kWh",
-            ),
+        hp_rows: list[tuple[str, str, str]] = [
+            ("Electricity — customer charge", f"${tt['elec_customer_charge']:.2f} /mo", "—"),
+            ("Electricity — RE Growth + LIHEAP", f"${tt['elec_other_fixed_charges']:.2f} /mo", "—"),
+            ("Electricity — HP delivery (EPMC)", "—", f"{tt['hp_flat_delivery_cents']:.2f} ¢/kWh"),
+            ("Electricity — HP supply (per-customer)", "—", f"{tt['hp_flat_supply_cents']:.2f} ¢/kWh"),
         ]
-        for tariff, fixed, vol in hp_tariff_rows:
+        for tariff, fixed, vol in hp_rows:
             ws.cell(row=row, column=1, value=tariff)
             ws.cell(row=row, column=2, value=fixed)
             ws.cell(row=row, column=3, value=vol)
@@ -356,90 +426,23 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         row += 1
         ws.cell(row=row, column=1, value="After tariffs")
         ws.cell(row=row, column=1).font = Font(bold=True)
-        ws.cell(
-            row=row,
-            column=2,
-            value="Same default tariffs as above (HP upgrade keeps current rates).",
-        )
+        ws.cell(row=row, column=2, value="Same default tariffs as above (HP upgrade keeps current rates).")
         ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
         row += 1
 
-    # --- How bills are computed -----------------------------------------------
+    # --- Gas seasonal rate detail -------------------------------------------
     row += 1
-    ws.cell(row=row, column=1, value="How bills are computed")
+    ws.cell(row=row, column=1, value="Gas seasonal rates ($/therm)")
     ws.cell(row=row, column=1).font = Font(bold=True)
     row += 1
-
-    how_rows: list[tuple[str, str]] = [
-        (
-            "Fixed charge",
-            f"${FIXED_CHARGE_PER_MONTH:.2f}/mo (${FIXED_CHARGE_PER_YEAR:.2f}/yr): "
-            "$6.00 customer charge + $3.22 RE Growth + $0.79 LIHEAP Enhancement. "
-            "Matches fixedchargefirstmeter in all calibrated tariff JSONs and the testimony.",
-        ),
-        (
-            "kWh source",
-            "Exported directly from CAIRO's billing pipeline (billing_kwh_annual.parquet). "
-            "These are grid-consumed kWh after PV clipping (max(electricity_net, 0)), "
-            "kwh_scale_factor application (0.9568), and 48-hour day-of-week timeshift. "
-            "Upgrade 0 = before HP, upgrade 2 = after HP.",
-        ),
-        (
-            "Electric bills",
-            "From CAIRO's hourly simulation (elec_total_bill). "
-            "CAIRO applies each hour's consumption to the applicable tariff rate and sums to the annual total.",
-        ),
-    ]
-    for label, value in how_rows:
-        ws.cell(row=row, column=1, value=label)
-        ws.cell(row=row, column=2, value=value)
-        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
-        row += 1
-
-    # --- Seasonal rate explanation for 1-8 ------------------------------------
-    if scenario_id == "1-8":
-        row += 1
-        ws.cell(row=row, column=1, value="Why no bill-verification formula (RIE 1-8)")
-        ws.cell(row=row, column=1).font = Font(bold=True)
-        row += 1
-        seasonal_text = (
-            "The default supply tariff (rie_default_supply_calibrated.json) uses three seasonal rates:\n"
-            " - Winter (Jan, Feb, Mar, Nov, Dec): 31.38 ¢/kWh\n"
-            " - Summer (Jun, Jul, Aug, Sep): 24.78 ¢/kWh\n"
-            " - Shoulder (Apr, May, Oct): 29.49 ¢/kWh\n\n"
-            "These rates bundle delivery + supply. Because each building has a different monthly "
-            "consumption profile, a single annual_kwh × rate formula cannot reproduce the bill — "  # noqa: RUF001
-            "it would require 12 monthly kWh values and per-month rate assignments. "
-            "CAIRO computes bills hourly (8,760 hours), applying the correct seasonal rate to each "
-            "hour's consumption, then sums to the annual total.\n\n"
-            "The elec_total_bill column is the exact annual bill from CAIRO. "
-            "To verify it independently, one would need the building's hourly load profile "
-            "(available in billing_kwh_8760.parquet) and the seasonal rate schedule above.\n\n"
-            "For RIE 1-9, the HP flat tariff uses a single year-round rate (23.13 ¢/kWh), so "
-            "annual_kwh × 0.23129 + 10.01 × 12 reproduces the bill within ~$1."  # noqa: RUF001
-        )
-        ws.cell(row=row, column=1, value=seasonal_text)
-        ws.cell(row=row, column=1).alignment = Alignment(wrap_text=True)
-        ws.merge_cells(start_row=row, start_column=1, end_row=row, end_column=3)
-        row += 1
-
-    # --- Bill verification formula for 1-9 ------------------------------------
-    if scenario_id == "1-9":
-        row += 1
-        ws.cell(row=row, column=1, value="Bill-verification formula (RIE 1-9)")
-        ws.cell(row=row, column=1).font = Font(bold=True)
-        row += 1
-        verify_text = (
-            f"The HP flat supply tariff (rie_hp_flat_supply_calibrated.json) uses a single flat rate "
-            f"of {HP_FLAT_COMBINED_RATE * 100:.2f} ¢/kWh (delivery + supply bundled). The verification formula is:\n\n"
-            f"  elec_bill_formula = annual_kwh_after × {HP_FLAT_COMBINED_RATE} + {FIXED_CHARGE_PER_MONTH} × 12\n\n"  # noqa: RUF001
-            "The elec_bill_residual column shows elec_bill_after - elec_bill_formula. "
-            "Residuals of ~$1 are expected due to CAIRO's hourly billing mechanics "
-            "(48-hour day-of-week timeshift aligning 2018 weather year to 2025)."
-        )
-        ws.cell(row=row, column=1, value=verify_text)
-        ws.cell(row=row, column=1).alignment = Alignment(wrap_text=True)
-        ws.merge_cells(start_row=row, start_column=1, end_row=row, end_column=3)
+    _header_fill(ws, row, 4)
+    for c, hdr in enumerate(["Month", "Heating (Rate 12)", "Non-heating (Rate 10)", "Notes"], 1):
+        ws.cell(row=row, column=c, value=hdr)
+    row += 1
+    for m in MONTH_ORDER:
+        ws.cell(row=row, column=1, value=m)
+        ws.cell(row=row, column=2, value=round(GAS_HEATING_PER_THERM[m], 4))
+        ws.cell(row=row, column=3, value=round(GAS_NONHEATING_PER_THERM[m], 4))
         row += 1
 
     # --- Data sources -------------------------------------------------------
@@ -448,8 +451,9 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         ("Data sources", ""),
         ("Before bills", f"{scen['before_desc']}\n{scen['before_path']}"),
         ("After bills", f"{scen['after_desc']}\n{scen['after_path']}"),
-        ("kWh (upgrade 0)", f"billing_kwh_annual.parquet from\n{PATH_KWH_U0}"),
-        ("kWh (upgrade 2)", f"billing_kwh_annual.parquet from\n{PATH_KWH_U2}"),
+        ("Electric kWh (8760, upgrade 0)", PATH_KWH_8760_U0),
+        ("Electric kWh (8760, upgrade 2)", PATH_KWH_8760_U2),
+        ("Gas consumption (ResStock monthly)", f"{RESSTOCK_RELEASE}/load_curve_monthly/state=RI/upgrade={{00,02}}/"),
         (
             "Analysis notebook",
             _reports2_permalink("reports/ri_hp_rates/notebooks/analysis.qmd"),
@@ -463,70 +467,31 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
         row += 1
 
-    # --- per_building columns -----------------------------------------------
+    # --- monthly columns description ----------------------------------------
     row += 1
-    col_rows: list[tuple[str, str]] = [
-        ("per_building columns", ""),
+    mcol_rows: list[tuple[str, str]] = [
+        ("monthly columns", ""),
         ("bldg_id", "ResStock building identifier"),
-        ("weight", "CAIRO sample weight (number of real households this building represents)"),
+        ("month", "Calendar month (Jan-Dec)"),
         (
-            "annual_kwh_before",
-            "Annual grid-consumed electricity (kWh), upgrade 0 (current HVAC). "
-            "Exported from CAIRO billing pipeline (billing_kwh_annual.parquet). "
-            "Reflects PV clipping, kwh_scale_factor (0.9568), and 48-hour timeshift.",
+            "elec_kwh_before",
+            "Monthly electric kWh, upgrade 0. Rolled from CAIRO 8760 billing kWh (post PV-clip, scale factor, timeshift).",
         ),
-        (
-            "annual_kwh_after",
-            "Annual grid-consumed electricity (kWh), upgrade 2 (heat pump). "
-            "Same source as above; same physical consumption regardless of tariff.",
-        ),
-        ("elec_bill_before", "Annual electric bill before HP, undiscounted"),
-        (
-            "elec_bill_lmi_before",
-            "Annual electric bill before HP, with LMI discount applied (32% of eligible households receive discount)",
-        ),
-        ("gas_bill_before", "Annual gas bill before HP, undiscounted (same as LMI; gas has no LMI discount)"),
-        (
-            "gas_bill_lmi_before",
-            "Annual gas bill before HP, with LMI discount applied (32% of eligible households receive discount)",
-        ),
-        ("oil_bill_before", "Annual heating oil bill before HP (no LMI discount applies)"),
-        ("propane_bill_before", "Annual propane bill before HP (no LMI discount applies)"),
-        ("elec_bill_after", "Annual electric bill after HP, undiscounted"),
-        ("elec_bill_lmi_after", "Annual electric bill after HP, with LMI discount applied"),
-        ("gas_bill_after", "Annual gas bill after HP, undiscounted"),
-        ("gas_bill_lmi_after", "Annual gas bill after HP, with LMI discount applied"),
-        ("oil_bill_after", "Annual heating oil bill after HP"),
-        ("propane_bill_after", "Annual propane bill after HP"),
-        ("elec_lmi_discount_before", "Formula: elec_bill_before - elec_bill_lmi_before (discount amount)"),
-        ("elec_lmi_discount_after", "Formula: elec_bill_after - elec_bill_lmi_after (discount amount)"),
-        (
-            "energy_bill_lmi_before",
-            "Formula: sum of LMI-adjusted fuel bills before HP (elec_lmi + gas_lmi + oil + propane)",
-        ),
-        ("energy_bill_lmi_after", "Formula: sum of LMI-adjusted fuel bills after HP"),
-        ("delta", "Formula: energy_bill_lmi_after - energy_bill_lmi_before (negative = savings)"),
-        ("saves", "Formula: 1 if delta < 0, else 0"),
-        ("w_saves", "Formula: weight * saves (weighted savings indicator)"),
+        ("elec_kwh_after", "Monthly electric kWh, upgrade 2. Same source."),
+        ("gas_therms_before", "Monthly gas therms, upgrade 0. From ResStock load_curve_monthly (/ 29.3 kWh/therm)."),
+        ("gas_therms_after", "Monthly gas therms, upgrade 2. Same source."),
+        ("elec_rate_before", "Combined electric rate (delivery + supply) for that month, $/kWh."),
+        ("elec_rate_after", "Combined electric rate for after scenario, $/kWh."),
+        ("elec_fixed", "$10.01/mo ($6.00 customer + $3.22 RE Growth + $0.79 LIHEAP)."),
+        ("gas_rate_before", "Gas heating tariff (Rate 12), seasonal $/therm."),
+        ("gas_rate_after", "Gas non-heating tariff (Rate 10), seasonal $/therm."),
+        ("gas_fixed", "$14.79/mo."),
+        ("elec_bill_before", "Formula: elec_kwh_before x elec_rate_before + elec_fixed."),
+        ("elec_bill_after", "Formula: elec_kwh_after x elec_rate_after + elec_fixed."),
+        ("gas_bill_before", "Formula: gas_therms_before x gas_rate_before + gas_fixed."),
+        ("gas_bill_after", "Formula: gas_therms_after x gas_rate_after + gas_fixed."),
     ]
-
-    # Add 1-9-specific formula columns
-    if scenario_id == "1-9":
-        col_rows.extend(
-            [
-                (
-                    "elec_bill_formula",
-                    f"Formula: annual_kwh_after × {HP_FLAT_COMBINED_RATE} + {FIXED_CHARGE_PER_MONTH} × 12. "  # noqa: RUF001
-                    "Verification of the CAIRO electric bill using the HP flat combined rate.",
-                ),
-                (
-                    "elec_bill_residual",
-                    "Formula: elec_bill_after - elec_bill_formula. Expected ~$1 from CAIRO's hourly billing mechanics.",
-                ),
-            ]
-        )
-
-    for label, value in col_rows:
+    for label, value in mcol_rows:
         ws.cell(row=row, column=1, value=label)
         if label in bold_labels:
             ws.cell(row=row, column=1).font = Font(bold=True)
@@ -534,47 +499,195 @@ def _write_assumptions(wb: Workbook, scenario_id: str, inputs: dict) -> None:
         ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
         row += 1
 
-    _autosize(ws, {"A": 44, "B": 40, "C": 36})
+    # --- annual columns description -----------------------------------------
+    row += 1
+    acol_rows: list[tuple[str, str]] = [
+        ("annual columns", ""),
+        ("bldg_id", "ResStock building identifier"),
+        ("weight", "CAIRO sample weight"),
+        ("annual_kwh_before / after", "SUM of monthly electric kWh"),
+        ("annual_therms_before / after", "SUM of monthly gas therms"),
+        ("elec_bill_before / after", "SUM of monthly elec_bill formula"),
+        (
+            "elec_bill_lmi_before / after",
+            "If building received LMI discount: discounted bill from master bills. Otherwise: =elec_bill (same as undiscounted).",
+        ),
+        ("gas_bill_before / after", "SUM of monthly gas_bill formula"),
+        (
+            "gas_bill_lmi_before / after",
+            "If building received LMI discount: discounted bill from master bills. Otherwise: =gas_bill (same as undiscounted).",
+        ),
+        ("oil_bill_before / after", "Annual oil bill (data from master bills)"),
+        ("propane_bill_before / after", "Annual propane bill (data from master bills)"),
+        ("energy_bill_lmi_before / after", "Sum of LMI-adjusted fuel bills"),
+        ("delta", "energy_bill_lmi_after - energy_bill_lmi_before"),
+        ("saves", "1 if delta < 0, else 0"),
+        ("w_saves", "weight x saves"),
+    ]
+    for label, value in acol_rows:
+        ws.cell(row=row, column=1, value=label)
+        if label in bold_labels:
+            ws.cell(row=row, column=1).font = Font(bold=True)
+        ws.cell(row=row, column=2, value=value)
+        ws.cell(row=row, column=2).alignment = Alignment(wrap_text=True)
+        row += 1
+
+    _autosize(ws, {"A": 44, "B": 40, "C": 36, "D": 36})
     ws.sheet_view.showGridLines = False
 
 
-def _write_per_building(wb: Workbook, gas: pl.DataFrame, scenario_id: str) -> int:
-    """Write per-building bills sheet. Returns the last data row number."""
-    ws = wb.create_sheet("per_building")
+def _write_monthly(
+    wb: Workbook,
+    monthly_data: pl.DataFrame,
+    scenario_id: str,
+) -> int:
+    """Write monthly derivation sheet. Returns number of buildings."""
+    ws = wb.create_sheet("monthly")
+
+    headers = [
+        "bldg_id",  # A
+        "month",  # B
+        "elec_kwh_before",  # C
+        "elec_kwh_after",  # D
+        "gas_therms_before",  # E  formula
+        "gas_therms_after",  # F  formula
+        "elec_rate_before",  # G  data
+        "elec_rate_after",  # H  data
+        "elec_fixed",  # I  data
+        "gas_rate_before",  # J  data
+        "gas_rate_after",  # K  data
+        "gas_fixed",  # L  data
+        "elec_bill_before",  # M  formula
+        "elec_bill_after",  # N  formula
+        "gas_bill_before",  # O  formula
+        "gas_bill_after",  # P  formula
+    ]
+    ws.append(headers)
+    _header_fill(ws, 1, len(headers))
+    ws.freeze_panes = "A2"
+
+    elec_rate_after_map: dict[str, float]
+    if scenario_id == "1-8":
+        elec_rate_after_map = ELEC_COMBINED_DEFAULT
+    else:
+        elec_rate_after_map = dict.fromkeys(MONTH_ORDER, HP_FLAT_COMBINED_RATE)
+
+    bldg_ids = monthly_data["bldg_id"].unique().sort().to_list()
+    n_buildings = len(bldg_ids)
+
+    r = 2  # current row
+    for bid in bldg_ids:
+        bldg_rows = monthly_data.filter(pl.col("bldg_id") == bid)
+        for m in MONTH_ORDER:
+            mrow = bldg_rows.filter(pl.col("month") == m)
+            elec_kwh_b = float(mrow["elec_kwh_before"][0])
+            elec_kwh_a = float(mrow["elec_kwh_after"][0])
+            gas_kwh_b = float(mrow["gas_kwh_before"][0])
+            gas_kwh_a = float(mrow["gas_kwh_after"][0])
+
+            elec_rate_b = ELEC_COMBINED_DEFAULT[m]
+            elec_rate_a = elec_rate_after_map[m]
+            gas_rate_b = GAS_HEATING_PER_THERM[m]
+            gas_rate_a = GAS_NONHEATING_PER_THERM[m]
+
+            ws.cell(row=r, column=1, value=bid)  # A: bldg_id
+            ws.cell(row=r, column=2, value=m)  # B: month
+            ws.cell(row=r, column=3, value=elec_kwh_b)  # C: elec_kwh_before
+            ws.cell(row=r, column=4, value=elec_kwh_a)  # D: elec_kwh_after
+            # E: gas_therms_before = gas_kwh / 29.3
+            ws.cell(row=r, column=5, value=gas_kwh_b / KWH_PER_THERM)
+            # F: gas_therms_after
+            ws.cell(row=r, column=6, value=gas_kwh_a / KWH_PER_THERM)
+            ws.cell(row=r, column=7, value=elec_rate_b)  # G
+            ws.cell(row=r, column=8, value=elec_rate_a)  # H
+            ws.cell(row=r, column=9, value=ELEC_FIXED_PER_MONTH)  # I
+            ws.cell(row=r, column=10, value=gas_rate_b)  # J
+            ws.cell(row=r, column=11, value=gas_rate_a)  # K
+            ws.cell(row=r, column=12, value=GAS_FIXED_PER_MONTH)  # L
+            # M: elec_bill_before = C*G + I
+            ws.cell(row=r, column=13, value=f"=C{r}*G{r}+I{r}")
+            # N: elec_bill_after = D*H + I
+            ws.cell(row=r, column=14, value=f"=D{r}*H{r}+I{r}")
+            # O: gas_bill_before = E*J + L
+            ws.cell(row=r, column=15, value=f"=E{r}*J{r}+L{r}")
+            # P: gas_bill_after = F*K + L
+            ws.cell(row=r, column=16, value=f"=F{r}*K{r}+L{r}")
+            r += 1
+
+    # Number formatting
+    last_row = r - 1
+    for row_i in range(2, last_row + 1):
+        for col in "CD":
+            ws[f"{col}{row_i}"].number_format = "#,##0.0"
+        for col in "EF":
+            ws[f"{col}{row_i}"].number_format = "#,##0.00"
+        for col in "GH":
+            ws[f"{col}{row_i}"].number_format = "0.00000"
+        ws[f"I{row_i}"].number_format = '"$"#,##0.00'
+        for col in "JK":
+            ws[f"{col}{row_i}"].number_format = '"$"#,##0.0000'
+        ws[f"L{row_i}"].number_format = '"$"#,##0.00'
+        for col in "MNOP":
+            ws[f"{col}{row_i}"].number_format = '"$"#,##0.00'
+
+    _autosize(
+        ws,
+        {
+            "A": 10,
+            "B": 8,
+            "C": 16,
+            "D": 16,
+            "E": 18,
+            "F": 18,
+            "G": 16,
+            "H": 16,
+            "I": 10,
+            "J": 16,
+            "K": 16,
+            "L": 10,
+            "M": 16,
+            "N": 16,
+            "O": 16,
+            "P": 16,
+        },
+    )
+    return n_buildings
+
+
+def _write_annual(
+    wb: Workbook,
+    annual_lmi: pl.DataFrame,
+    scenario_id: str,
+    n_buildings: int,
+) -> int:
+    """Write annual summary sheet. Returns the last data row number."""
+    ws = wb.create_sheet("annual")
 
     headers = [
         "bldg_id",  # A
         "weight",  # B
-        "annual_kwh_before",  # C  data (upgrade 0)
-        "annual_kwh_after",  # D  data (upgrade 2)
-        "elec_bill_before",  # E
-        "elec_bill_lmi_before",  # F
-        "gas_bill_before",  # G
-        "gas_bill_lmi_before",  # H
-        "oil_bill_before",  # I
-        "propane_bill_before",  # J
-        "elec_bill_after",  # K
-        "elec_bill_lmi_after",  # L
-        "gas_bill_after",  # M
-        "gas_bill_lmi_after",  # N
-        "oil_bill_after",  # O
-        "propane_bill_after",  # P
-        "elec_lmi_discount_before",  # Q  formula
-        "elec_lmi_discount_after",  # R  formula
+        "annual_kwh_before",  # C  SUM
+        "annual_kwh_after",  # D  SUM
+        "annual_therms_before",  # E  SUM
+        "annual_therms_after",  # F  SUM
+        "elec_bill_before",  # G  SUM
+        "elec_bill_lmi_before",  # H  data
+        "gas_bill_before",  # I  SUM
+        "gas_bill_lmi_before",  # J  data
+        "oil_bill_before",  # K  data
+        "propane_bill_before",  # L  data
+        "elec_bill_after",  # M  SUM
+        "elec_bill_lmi_after",  # N  data
+        "gas_bill_after",  # O  SUM
+        "gas_bill_lmi_after",  # P  data
+        "oil_bill_after",  # Q  data
+        "propane_bill_after",  # R  data
         "energy_bill_lmi_before",  # S  formula
         "energy_bill_lmi_after",  # T  formula
         "delta",  # U  formula
         "saves",  # V  formula
         "w_saves",  # W  formula
     ]
-    if scenario_id == "1-9":
-        headers.extend(
-            [
-                "elec_bill_formula",  # X  formula (1-9 only)
-                "elec_bill_residual",  # Y  formula (1-9 only)
-            ]
-        )
-
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
     ws.freeze_panes = "A2"
@@ -582,92 +695,131 @@ def _write_per_building(wb: Workbook, gas: pl.DataFrame, scenario_id: str) -> in
     data_cols = [
         "bldg_id",
         "weight",
-        "annual_kwh_before",
-        "annual_kwh_after",
-        "elec_total_bill_before",
+        "has_elec_discount",
+        "has_gas_discount",
         "elec_total_bill_lmi_32_before",
-        "gas_total_bill_before",
         "gas_total_bill_lmi_32_before",
         "oil_total_bill_before",
         "propane_total_bill_before",
-        "elec_total_bill_after",
+        "has_elec_discount_after",
+        "has_gas_discount_after",
         "elec_total_bill_lmi_32_after",
-        "gas_total_bill_after",
         "gas_total_bill_lmi_32_after",
         "oil_total_bill_after",
         "propane_total_bill_after",
     ]
 
-    rows = list(gas.select(data_cols).iter_rows())
-    for i, row in enumerate(rows, start=2):
-        for ci, val in enumerate(row, start=1):
-            ws.cell(row=i, column=ci, value=float(val) if ci > 1 else val)
-        # Q: elec LMI discount before = E - F
-        ws.cell(row=i, column=17, value=f"=E{i}-F{i}")
-        # R: elec LMI discount after = K - L
-        ws.cell(row=i, column=18, value=f"=K{i}-L{i}")
-        # S: energy_bill_lmi_before = F + H + I + J
-        ws.cell(row=i, column=19, value=f"=F{i}+H{i}+I{i}+J{i}")
-        # T: energy_bill_lmi_after = L + N + O + P
-        ws.cell(row=i, column=20, value=f"=L{i}+N{i}+O{i}+P{i}")
-        # U: delta = T - S
-        ws.cell(row=i, column=21, value=f"=T{i}-S{i}")
-        # V: saves = IF(U < 0, 1, 0)
-        ws.cell(row=i, column=22, value=f"=IF(U{i}<0,1,0)")
-        # W: w_saves = weight * saves
-        ws.cell(row=i, column=23, value=f"=B{i}*V{i}")
+    rows_list = list(annual_lmi.select(data_cols).iter_rows())
+    for i, row_data in enumerate(rows_list):
+        ar = i + 2  # annual sheet row
+        ms = 2 + i * 12  # monthly start row
+        me = ms + 11  # monthly end row
 
-        if scenario_id == "1-9":
-            # X: elec_bill_formula = annual_kwh_after * rate + fixed * 12
-            ws.cell(row=i, column=24, value=f"=D{i}*{HP_FLAT_COMBINED_RATE}+{FIXED_CHARGE_PER_MONTH}*12")
-            # Y: elec_bill_residual = elec_bill_after - elec_bill_formula
-            ws.cell(row=i, column=25, value=f"=K{i}-X{i}")
+        (
+            bid,
+            weight,
+            has_elec_disc_b,
+            has_gas_disc_b,
+            elec_lmi_b,
+            gas_lmi_b,
+            oil_b,
+            propane_b,
+            has_elec_disc_a,
+            has_gas_disc_a,
+            elec_lmi_a,
+            gas_lmi_a,
+            oil_a,
+            propane_a,
+        ) = row_data
 
-    last_row = 1 + len(rows)
+        ws.cell(row=ar, column=1, value=bid)  # A
+        ws.cell(row=ar, column=2, value=float(weight))  # B
+        ws.cell(row=ar, column=3, value=f"=SUM(monthly!C{ms}:C{me})")  # C: kwh before
+        ws.cell(row=ar, column=4, value=f"=SUM(monthly!D{ms}:D{me})")  # D: kwh after
+        ws.cell(row=ar, column=5, value=f"=SUM(monthly!E{ms}:E{me})")  # E: therms before
+        ws.cell(row=ar, column=6, value=f"=SUM(monthly!F{ms}:F{me})")  # F: therms after
+        ws.cell(row=ar, column=7, value=f"=SUM(monthly!M{ms}:M{me})")  # G: elec bill before (SUM)
+        # H: elec LMI before — discounted value if LMI, else =G (matches undiscounted)
+        if has_elec_disc_b:
+            ws.cell(row=ar, column=8, value=float(elec_lmi_b))
+        else:
+            ws.cell(row=ar, column=8, value=f"=G{ar}")
+        ws.cell(row=ar, column=9, value=f"=SUM(monthly!O{ms}:O{me})")  # I: gas bill before (SUM)
+        # J: gas LMI before
+        if has_gas_disc_b:
+            ws.cell(row=ar, column=10, value=float(gas_lmi_b))
+        else:
+            ws.cell(row=ar, column=10, value=f"=I{ar}")
+        ws.cell(row=ar, column=11, value=float(oil_b))  # K: oil before
+        ws.cell(row=ar, column=12, value=float(propane_b))  # L: propane before
+        ws.cell(row=ar, column=13, value=f"=SUM(monthly!N{ms}:N{me})")  # M: elec bill after (SUM)
+        # N: elec LMI after
+        if has_elec_disc_a:
+            ws.cell(row=ar, column=14, value=float(elec_lmi_a))
+        else:
+            ws.cell(row=ar, column=14, value=f"=M{ar}")
+        ws.cell(row=ar, column=15, value=f"=SUM(monthly!P{ms}:P{me})")  # O: gas bill after (SUM)
+        # P: gas LMI after
+        if has_gas_disc_a:
+            ws.cell(row=ar, column=16, value=float(gas_lmi_a))
+        else:
+            ws.cell(row=ar, column=16, value=f"=O{ar}")
+        ws.cell(row=ar, column=17, value=float(oil_a))  # Q: oil after
+        ws.cell(row=ar, column=18, value=float(propane_a))  # R: propane after
+        # S: energy_bill_lmi_before = H + J + K + L
+        ws.cell(row=ar, column=19, value=f"=H{ar}+J{ar}+K{ar}+L{ar}")
+        # T: energy_bill_lmi_after = N + P + Q + R
+        ws.cell(row=ar, column=20, value=f"=N{ar}+P{ar}+Q{ar}+R{ar}")
+        # U: delta
+        ws.cell(row=ar, column=21, value=f"=T{ar}-S{ar}")
+        # V: saves
+        ws.cell(row=ar, column=22, value=f"=IF(U{ar}<0,1,0)")
+        # W: w_saves
+        ws.cell(row=ar, column=23, value=f"=B{ar}*V{ar}")
+
+    last_row = 1 + len(rows_list)
 
     for r in range(2, last_row + 1):
         for col in "CD":
             ws[f"{col}{r}"].number_format = "#,##0"
-        for col in "EFGHIJKLMNOPQRSTU":
+        for col in "EF":
+            ws[f"{col}{r}"].number_format = "#,##0.0"
+        for col in "GHIJKLMNOPQRSTU":
             ws[f"{col}{r}"].number_format = '"$"#,##0.00'
-        if scenario_id == "1-9":
-            ws[f"X{r}"].number_format = '"$"#,##0.00'
-            ws[f"Y{r}"].number_format = '"$"#,##0.00'
 
-    widths: dict[str, int] = {
-        "A": 10,
-        "B": 10,
-        "C": 18,
-        "D": 18,
-        "E": 16,
-        "F": 18,
-        "G": 16,
-        "H": 18,
-        "I": 14,
-        "J": 16,
-        "K": 16,
-        "L": 18,
-        "M": 16,
-        "N": 18,
-        "O": 14,
-        "P": 16,
-        "Q": 22,
-        "R": 22,
-        "S": 22,
-        "T": 22,
-        "U": 14,
-        "V": 8,
-        "W": 12,
-    }
-    if scenario_id == "1-9":
-        widths["X"] = 18
-        widths["Y"] = 18
-    _autosize(ws, widths)
+    _autosize(
+        ws,
+        {
+            "A": 10,
+            "B": 10,
+            "C": 18,
+            "D": 16,
+            "E": 18,
+            "F": 18,
+            "G": 16,
+            "H": 18,
+            "I": 16,
+            "J": 18,
+            "K": 14,
+            "L": 16,
+            "M": 16,
+            "N": 18,
+            "O": 16,
+            "P": 18,
+            "Q": 14,
+            "R": 16,
+            "S": 22,
+            "T": 22,
+            "U": 14,
+            "V": 8,
+            "W": 12,
+        },
+    )
     return last_row
 
 
 def _write_result(wb: Workbook, last_row: int, scenario_id: str) -> None:
-    """Summary sheet deriving the headline percentage with formulas."""
+    """Summary sheet deriving the headline percentage."""
     ws = wb.create_sheet("result")
     scen = SCENARIOS[scenario_id]
 
@@ -680,23 +832,19 @@ def _write_result(wb: Workbook, last_row: int, scenario_id: str) -> None:
         ws.cell(row=hdr_row, column=ci, value=h)
     _header_fill(ws, hdr_row, 3)
 
-    # Row 4: total gas-heated customers (weighted)
     ws.cell(row=4, column=1, value="Gas-heated customers (weighted)")
-    ws.cell(row=4, column=2, value=f"=SUM(per_building!B2:B{last_row})")
+    ws.cell(row=4, column=2, value=f"=SUM(annual!B2:B{last_row})")
     ws.cell(row=4, column=3, value="SUM of weights (all rows are gas-heated)")
 
-    # Row 5: gas-heated customers that save
     ws.cell(row=5, column=1, value="Gas-heated customers that save")
-    ws.cell(row=5, column=2, value=f"=SUM(per_building!W2:W{last_row})")
+    ws.cell(row=5, column=2, value=f"=SUM(annual!W2:W{last_row})")
     ws.cell(row=5, column=3, value="SUM of weighted saves indicator")
 
-    # Row 6: pct save
     ws.cell(row=6, column=1, value="Percentage that save")
     ws.cell(row=6, column=2, value="=B5/B4")
     ws.cell(row=6, column=3, value="weighted_savers / total_weighted")
     ws.cell(row=6, column=2).number_format = "0.0%"
 
-    # Row 7: pct lose
     ws.cell(row=7, column=1, value="Percentage that lose")
     ws.cell(row=7, column=2, value="=1-B6")
     ws.cell(row=7, column=3, value="1 - pct_save")
@@ -709,7 +857,6 @@ def _write_result(wb: Workbook, last_row: int, scenario_id: str) -> None:
     for r in (4, 5):
         ws[f"B{r}"].number_format = "#,##0.00"
 
-    # Bold the headline row
     if scenario_id == "1-8":
         ws.cell(row=7, column=1).font = Font(bold=True)
         ws.cell(row=7, column=2).font = Font(bold=True)
@@ -722,49 +869,29 @@ def _write_result(wb: Workbook, last_row: int, scenario_id: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Validation.
-# ---------------------------------------------------------------------------
-def _validate_kwh_consistency(gas_18: pl.DataFrame, gas_19: pl.DataFrame) -> None:
-    """Assert kWh values are identical between 1-8 and 1-9 DataFrames."""
-    merged = gas_18.select("bldg_id", "annual_kwh_before", "annual_kwh_after").join(
-        gas_19.select(
-            "bldg_id",
-            pl.col("annual_kwh_before").alias("kwh_before_19"),
-            pl.col("annual_kwh_after").alias("kwh_after_19"),
-        ),
-        on="bldg_id",
-        how="inner",
-    )
-    assert merged.height == gas_18.height == gas_19.height, (
-        f"Building count mismatch: 1-8={gas_18.height}, 1-9={gas_19.height}, joined={merged.height}"
-    )
-    before_diff = float((merged["annual_kwh_before"] - merged["kwh_before_19"]).abs().max())  # type: ignore[arg-type]
-    after_diff = float((merged["annual_kwh_after"] - merged["kwh_after_19"]).abs().max())  # type: ignore[arg-type]
-    assert before_diff < 0.01, f"kWh_before differs: max diff = {before_diff}"
-    assert after_diff < 0.01, f"kWh_after differs: max diff = {after_diff}"
-    print(
-        f"  kWh consistency: {merged.height} buildings, "
-        f"before max_diff={before_diff:.2e}, after max_diff={after_diff:.2e}",
-        flush=True,
-    )
-
-
-# ---------------------------------------------------------------------------
 # Orchestration.
 # ---------------------------------------------------------------------------
 def build_workbook(
     output_path: Path,
     scenario_id: str,
-    gas: pl.DataFrame,
+    monthly_data: pl.DataFrame,
+    annual_lmi: pl.DataFrame,
     inputs: dict,
 ) -> Path:
     """Build one workbook for the given scenario."""
-    total_w = float(gas["weight"].sum())
-    save_w = float(gas.filter(pl.col("delta") < 0)["weight"].sum())
+    total_w = float(annual_lmi["weight"].sum())
+    save_w = float(
+        annual_lmi.with_columns(
+            pl.sum_horizontal([f"{c}_before" for c in LMI_BILL_COLS]).alias("e_before"),
+            pl.sum_horizontal([f"{c}_after" for c in LMI_BILL_COLS]).alias("e_after"),
+        )
+        .filter(pl.col("e_after") < pl.col("e_before"))["weight"]
+        .sum()
+    )
     pct_save = save_w / total_w
 
     print(f"\n  RIE {scenario_id}:", flush=True)
-    print(f"    gas-heated buildings: {gas.height:,}", flush=True)
+    print(f"    gas-heated buildings: {annual_lmi.height:,}", flush=True)
     print(f"    weighted customers: {total_w:,.1f}", flush=True)
     print(f"    pct save: {pct_save:.4f} ({pct_save * 100:.1f}%)", flush=True)
     print(f"    pct lose: {1 - pct_save:.4f} ({(1 - pct_save) * 100:.1f}%)", flush=True)
@@ -785,15 +912,13 @@ def build_workbook(
         wb.remove(default_ws)
 
     _write_assumptions(wb, scenario_id, inputs)
-    last_row = _write_per_building(wb, gas, scenario_id)
+    n_buildings = _write_monthly(wb, monthly_data, scenario_id)
+    last_row = _write_annual(wb, annual_lmi, scenario_id, n_buildings)
     _write_result(wb, last_row, scenario_id)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     wb.save(str(output_path))
-    print(
-        f"    Wrote {output_path} ({output_path.stat().st_size / 1024:.1f} KB)",
-        flush=True,
-    )
+    print(f"    Wrote {output_path} ({output_path.stat().st_size / 1024:.1f} KB)", flush=True)
     return output_path
 
 
@@ -801,32 +926,6 @@ def build_workbook(
 # Google Sheets upload.
 # ---------------------------------------------------------------------------
 def _tab_formatting(scenario_id: str) -> dict[str, dict]:
-    number_formats = {
-        "C": "#,##0",
-        "D": "#,##0",
-        "E": '"$"#,##0.00',
-        "F": '"$"#,##0.00',
-        "G": '"$"#,##0.00',
-        "H": '"$"#,##0.00',
-        "I": '"$"#,##0.00',
-        "J": '"$"#,##0.00',
-        "K": '"$"#,##0.00',
-        "L": '"$"#,##0.00',
-        "M": '"$"#,##0.00',
-        "N": '"$"#,##0.00',
-        "O": '"$"#,##0.00',
-        "P": '"$"#,##0.00',
-        "Q": '"$"#,##0.00',
-        "R": '"$"#,##0.00',
-        "S": '"$"#,##0.00',
-        "T": '"$"#,##0.00',
-        "U": '"$"#,##0.00',
-    }
-    auto_range = "A:W"
-    if scenario_id == "1-9":
-        number_formats["X"] = '"$"#,##0.00'
-        number_formats["Y"] = '"$"#,##0.00'
-        auto_range = "A:Y"
     return {
         "assumptions": {
             "wrap_columns": ["B:B"],
@@ -834,9 +933,36 @@ def _tab_formatting(scenario_id: str) -> dict[str, dict]:
             "freeze_rows": 0,
             "bold_header": False,
         },
-        "per_building": {
-            "column_number_formats": number_formats,
-            "auto_resize_columns": [auto_range],
+        "monthly": {
+            "column_number_formats": {
+                "C": "#,##0.0",
+                "D": "#,##0.0",
+                "E": "#,##0.00",
+                "F": "#,##0.00",
+                "G": "0.00000",
+                "H": "0.00000",
+                "I": '"$"#,##0.00',
+                "J": '"$"#,##0.0000',
+                "K": '"$"#,##0.0000',
+                "L": '"$"#,##0.00',
+                "M": '"$"#,##0.00',
+                "N": '"$"#,##0.00',
+                "O": '"$"#,##0.00',
+                "P": '"$"#,##0.00',
+            },
+            "auto_resize_columns": ["A:P"],
+            "freeze_rows": 1,
+            "bold_header": True,
+        },
+        "annual": {
+            "column_number_formats": {
+                "C": "#,##0",
+                "D": "#,##0",
+                "E": "#,##0.0",
+                "F": "#,##0.0",
+                **dict.fromkeys("GHIJKLMNOPQRSTU", '"$"#,##0.00'),
+            },
+            "auto_resize_columns": ["A:W"],
             "freeze_rows": 1,
             "bold_header": True,
         },
@@ -869,47 +995,141 @@ def upload_to_sheet(xlsx_path: Path, spreadsheet_id: str, scenario_id: str) -> N
 # ---------------------------------------------------------------------------
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
-    parser.add_argument(
-        "--upload",
-        action="store_true",
-        help="Upload to Google Sheets after building.",
-    )
+    parser.add_argument("--upload", action="store_true", help="Upload to Google Sheets after building.")
     args = parser.parse_args(argv)
 
     print("Loading tariff inputs ...", flush=True)
     inputs = _load_inputs()
-    print(f"  fixed_charge = ${FIXED_CHARGE_PER_MONTH:.2f}/mo (${FIXED_CHARGE_PER_YEAR:.2f}/yr)", flush=True)
 
-    print("Loading billing kWh (upgrade 0 from run-1, upgrade 2 from run-3) ...", flush=True)
-    kwh_before = _load_billing_kwh(PATH_KWH_U0)
-    kwh_after = _load_billing_kwh(PATH_KWH_U2)
-    print(
-        f"  upgrade 0: {kwh_before.height:,} buildings, "
-        f"median {kwh_before['annual_kwh_grid'].median():,.0f} kWh\n"
-        f"  upgrade 2: {kwh_after.height:,} buildings, "
-        f"median {kwh_after['annual_kwh_grid'].median():,.0f} kWh",
-        flush=True,
-    )
+    # --- Load electric kWh (8760 → monthly) --------------------------------
+    print("Loading billing kWh 8760 (upgrade 0) ...", flush=True)
+    elec_monthly_u0 = _load_monthly_elec_kwh(PATH_KWH_8760_U0)
+    print(f"  {elec_monthly_u0['bldg_id'].n_unique()} buildings, {elec_monthly_u0.height} rows", flush=True)
 
+    print("Loading billing kWh 8760 (upgrade 2) ...", flush=True)
+    elec_monthly_u2 = _load_monthly_elec_kwh(PATH_KWH_8760_U2)
+    print(f"  {elec_monthly_u2['bldg_id'].n_unique()} buildings, {elec_monthly_u2.height} rows", flush=True)
+
+    # --- Load master bills -------------------------------------------------
     print("Loading master bills (run 1+2) ...", flush=True)
-    before = _load_annual_bills(PATH_BILLS_12)
-    print(f"  {before.height:,} annual rows for {UTILITY}", flush=True)
+    bills_12 = _load_bills(PATH_BILLS_12)
+    print(f"  {bills_12.height:,} rows", flush=True)
 
     print("Loading master bills (run 3+4) ...", flush=True)
-    after_default = _load_annual_bills(PATH_BILLS_34)
-    print(f"  {after_default.height:,} rows", flush=True)
+    bills_34 = _load_bills(PATH_BILLS_34)
+    print(f"  {bills_34.height:,} rows", flush=True)
 
     print("Loading master bills (run 19+20) ...", flush=True)
-    after_hprate = _load_annual_bills(PATH_BILLS_1920)
-    print(f"  {after_hprate.height:,} rows", flush=True)
+    bills_1920 = _load_bills(PATH_BILLS_1920)
+    print(f"  {bills_1920.height:,} rows", flush=True)
 
-    gas_default = _join_and_filter(before, after_default, kwh_before, kwh_after)
-    gas_hprate = _join_and_filter(before, after_hprate, kwh_before, kwh_after)
+    # --- Get gas-heated building IDs from before bills ---------------------
+    annual_before = bills_12.filter(pl.col("month") == "Annual")
+    gas_bldg_ids: list[int] = annual_before.filter(pl.col("heats_with_natgas"))["bldg_id"].sort().to_list()
+    print(f"Gas-heated buildings: {len(gas_bldg_ids)}", flush=True)
 
-    _validate_kwh_consistency(gas_default, gas_hprate)
+    # --- Load gas consumption from ResStock --------------------------------
+    print("Loading ResStock monthly gas (upgrade 0) ...", flush=True)
+    gas_monthly_u0 = _load_monthly_gas_kwh(gas_bldg_ids, "00")
+    print(f"  {gas_monthly_u0.height} rows", flush=True)
 
-    out_1_8 = build_workbook(Path("cache/rie_1_8.xlsx"), "1-8", gas_default, inputs)
-    out_1_9 = build_workbook(Path("cache/rie_1_9.xlsx"), "1-9", gas_hprate, inputs)
+    print("Loading ResStock monthly gas (upgrade 2) ...", flush=True)
+    gas_monthly_u2 = _load_monthly_gas_kwh(gas_bldg_ids, "02")
+    print(f"  {gas_monthly_u2.height} rows", flush=True)
+
+    # --- Build monthly data for gas-heated buildings -----------------------
+    def _build_monthly(scenario_id: str) -> pl.DataFrame:
+        """Join electric + gas consumption for 12 months per gas-heated building."""
+        elec_rate_after = (
+            ELEC_COMBINED_DEFAULT if scenario_id == "1-8" else dict.fromkeys(MONTH_ORDER, HP_FLAT_COMBINED_RATE)
+        )
+        rate_df = pl.DataFrame(
+            {
+                "month": MONTH_ORDER,
+                "elec_rate_before": [ELEC_COMBINED_DEFAULT[m] for m in MONTH_ORDER],
+                "elec_rate_after": [elec_rate_after[m] for m in MONTH_ORDER],
+                "gas_rate_before": [GAS_HEATING_PER_THERM[m] for m in MONTH_ORDER],
+                "gas_rate_after": [GAS_NONHEATING_PER_THERM[m] for m in MONTH_ORDER],
+            }
+        )
+
+        elec_before = elec_monthly_u0.filter(pl.col("bldg_id").is_in(gas_bldg_ids)).rename(
+            {"elec_kwh": "elec_kwh_before"}
+        )
+
+        elec_after = elec_monthly_u2.filter(pl.col("bldg_id").is_in(gas_bldg_ids)).rename(
+            {"elec_kwh": "elec_kwh_after"}
+        )
+
+        gas_before = gas_monthly_u0.rename({"gas_kwh": "gas_kwh_before"})
+        gas_after = gas_monthly_u2.rename({"gas_kwh": "gas_kwh_after"})
+
+        monthly = (
+            elec_before.join(elec_after, on=["bldg_id", "month"])
+            .join(gas_before, on=["bldg_id", "month"])
+            .join(gas_after, on=["bldg_id", "month"])
+            .join(rate_df, on="month")
+        )
+
+        # Sort by bldg_id, then month order
+        month_enum = pl.Enum(MONTH_ORDER)
+        return (
+            monthly.with_columns(pl.col("month").cast(month_enum).alias("_month_sort"))
+            .sort("bldg_id", "_month_sort")
+            .drop("_month_sort")
+        )
+
+    def _build_annual_lmi(bills_before: pl.DataFrame, bills_after: pl.DataFrame) -> pl.DataFrame:
+        """Annual bills (undiscounted + LMI + discount flags) for the annual sheet."""
+        all_bill_cols = [*LMI_BILL_COLS]
+        before_annual = (
+            bills_before.filter((pl.col("month") == "Annual") & pl.col("heats_with_natgas"))
+            .with_columns(
+                (pl.col("elec_total_bill") != pl.col("elec_total_bill_lmi_32")).alias("has_elec_discount"),
+                (pl.col("gas_total_bill") != pl.col("gas_total_bill_lmi_32")).alias("has_gas_discount"),
+            )
+            .select(
+                "bldg_id",
+                "weight",
+                "has_elec_discount",
+                "has_gas_discount",
+                *[pl.col(c).alias(f"{c}_before") for c in all_bill_cols],
+            )
+        )
+        after_annual = (
+            bills_after.filter((pl.col("month") == "Annual") & pl.col("heats_with_natgas"))
+            .with_columns(
+                (pl.col("elec_total_bill") != pl.col("elec_total_bill_lmi_32")).alias("has_elec_discount_after"),
+                (pl.col("gas_total_bill") != pl.col("gas_total_bill_lmi_32")).alias("has_gas_discount_after"),
+            )
+            .select(
+                "bldg_id",
+                "has_elec_discount_after",
+                "has_gas_discount_after",
+                *[pl.col(c).alias(f"{c}_after") for c in all_bill_cols],
+            )
+        )
+        return before_annual.join(after_annual, on="bldg_id").sort("bldg_id")
+
+    monthly_default = _build_monthly("1-8")
+    monthly_hprate = _build_monthly("1-9")
+    annual_lmi_default = _build_annual_lmi(bills_12, bills_34)
+    annual_lmi_hprate = _build_annual_lmi(bills_12, bills_1920)
+
+    out_1_8 = build_workbook(
+        Path("cache/rie_1_8.xlsx"),
+        "1-8",
+        monthly_default,
+        annual_lmi_default,
+        inputs,
+    )
+    out_1_9 = build_workbook(
+        Path("cache/rie_1_9.xlsx"),
+        "1-9",
+        monthly_hprate,
+        annual_lmi_hprate,
+        inputs,
+    )
 
     if args.upload:
         print("\nUploading ...", flush=True)
@@ -917,44 +1137,6 @@ def main(argv: list[str] | None = None) -> int:
         upload_to_sheet(out_1_9, SPREADSHEET_1_9, "1-9")
 
     return 0
-
-
-def _join_and_filter(
-    before: pl.DataFrame,
-    after: pl.DataFrame,
-    kwh_before: pl.DataFrame,
-    kwh_after: pl.DataFrame,
-) -> pl.DataFrame:
-    """Join before/after on bldg_id, filter to gas-heated, add kWh + LMI totals + delta."""
-    before_r = before.rename({c: f"{c}_before" for c in BILL_COLS}).select(
-        "bldg_id",
-        "weight",
-        "heats_with_natgas",
-        *[f"{c}_before" for c in BILL_COLS],
-    )
-    after_r = after.select(
-        "bldg_id",
-        *[pl.col(c).alias(f"{c}_after") for c in BILL_COLS],
-    )
-    joined = before_r.join(after_r, on="bldg_id", how="inner")
-    joined = joined.join(
-        kwh_before.select("bldg_id", pl.col("annual_kwh_grid").alias("annual_kwh_before")),
-        on="bldg_id",
-        how="left",
-    )
-    joined = joined.join(
-        kwh_after.select("bldg_id", pl.col("annual_kwh_grid").alias("annual_kwh_after")),
-        on="bldg_id",
-        how="left",
-    )
-    gas = joined.filter(pl.col("heats_with_natgas"))
-
-    return gas.with_columns(
-        pl.sum_horizontal([f"{c}_before" for c in LMI_BILL_COLS]).alias("energy_bill_lmi_before"),
-        pl.sum_horizontal([f"{c}_after" for c in LMI_BILL_COLS]).alias("energy_bill_lmi_after"),
-    ).with_columns(
-        (pl.col("energy_bill_lmi_after") - pl.col("energy_bill_lmi_before")).alias("delta"),
-    )
 
 
 if __name__ == "__main__":

--- a/reports/ri_hp_rates/testimony_response/build_marginal_costs_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_marginal_costs_workbook.py
@@ -67,6 +67,7 @@ RDP_GITHUB_BASE = "https://github.com/switchbox-data/rate-design-platform/blob"
 REPORTS2_GITHUB_BASE = "https://github.com/switchbox-data/reports2/blob"
 
 DEFAULT_SPREADSHEET_ID = "1GmLOgM90orMbFnhFti169idl9Li6QM8_IQKRWGhEct8"
+DELIVERY_ONLY_SPREADSHEET_ID = "1JvDqZjE1ZpHWi3hPU-_q4LxF7TxwCGFuUm7rBMX3vT0"
 
 
 # ── Permalink helpers ─────────────────────────────────────────────────────────
@@ -93,6 +94,8 @@ def _reports2_permalink(rel_path: str) -> str:
     """SHA-pinned GitHub permalink for a file in the reports2 repo."""
     return f"{REPORTS2_GITHUB_BASE}/{_reports2_head_sha()}/{rel_path}"
 
+
+_README_BOLD_ROWS: list[int] = []
 
 # ── Formatting helpers ────────────────────────────────────────────────────────
 
@@ -252,15 +255,21 @@ REF_AESC_PTF = "inputs_scalars!$B$2"
 REF_SUB_TX_DIST = "inputs_scalars!$B$3"
 REF_FCA_BLENDED = "inputs_scalars!$B$4"
 REF_N_PEAK = "inputs_scalars!$B$5"
+REF_N_PEAK_DELIVERY_ONLY = "inputs_scalars!$B$4"
 
 
 # ── Tab writers ───────────────────────────────────────────────────────────────
 
 
-def _write_readme(wb: Workbook) -> None:
+def _write_readme(wb: Workbook, *, delivery_only: bool = False) -> None:
     ws = wb.create_sheet("README", 0)
+    title = (
+        "Marginal Costs Workbook — RIE 2025 (delivery-only: bulk TX + dist/sub-TX)"
+        if delivery_only
+        else "Marginal Costs Workbook — RIE 2025 (5-component 8760 derivation)"
+    )
     rows: list[list] = [
-        ["Marginal Costs Workbook — RIE 2025 (5-component 8760 derivation)", "", ""],
+        [title, "", ""],
         ["", "", ""],
         # --- Item / Source / Notes section ---
         ["Item", "Source", "Notes"],
@@ -269,41 +278,53 @@ def _write_readme(wb: Workbook) -> None:
             _rdp_permalink("utils/pre/marginal_costs/generate_utility_tx_dx_mc.py"),
             "Produces dist_and_sub_tx parquet via PoP (probability of peak) on utility load.",
         ],
-        [
-            "Generator: supply energy MC",
-            _rdp_permalink("utils/pre/marginal_costs/generate_supply_energy_mc.py"),
-            "LMP/1000 direct conversion.",
-        ],
-        [
-            "Generator: supply capacity MC",
-            _rdp_permalink("utils/pre/marginal_costs/generate_supply_capacity_mc.py"),
-            "FCA exceedance on SENE aggregate load.",
-        ],
-        [
-            "Generator: supply ancillary MC",
-            _rdp_permalink("utils/pre/marginal_costs/generate_supply_ancillary_mc.py"),
-            "Regulation (service + capacity) / 1000.",
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "Generator: supply energy MC",
+                    _rdp_permalink("utils/pre/marginal_costs/generate_supply_energy_mc.py"),
+                    "LMP/1000 direct conversion.",
+                ],
+                [
+                    "Generator: supply capacity MC",
+                    _rdp_permalink("utils/pre/marginal_costs/generate_supply_capacity_mc.py"),
+                    "FCA exceedance on SENE aggregate load.",
+                ],
+                [
+                    "Generator: supply ancillary MC",
+                    _rdp_permalink("utils/pre/marginal_costs/generate_supply_ancillary_mc.py"),
+                    "Regulation (service + capacity) / 1000.",
+                ],
+            ]
+        ),
         [
             "Generator: bulk TX MC",
             _rdp_permalink("utils/pre/marginal_costs/generate_bulk_tx_mc.py"),
             "AESC PTF exceedance on NE system load.",
         ],
-        [
-            "Core: supply_energy.py",
-            _rdp_permalink("utils/pre/marginal_costs/supply_energy.py"),
-            "ISO-NE LMP loading and energy MC computation.",
-        ],
-        [
-            "Core: supply_capacity_isone.py",
-            _rdp_permalink("utils/pre/marginal_costs/supply_capacity_isone.py"),
-            "FCA price resolution and capacity exceedance allocation.",
-        ],
-        [
-            "Core: supply_ancillary.py",
-            _rdp_permalink("utils/pre/marginal_costs/supply_ancillary.py"),
-            "Ancillary regulation price loading.",
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "Core: supply_energy.py",
+                    _rdp_permalink("utils/pre/marginal_costs/supply_energy.py"),
+                    "ISO-NE LMP loading and energy MC computation.",
+                ],
+                [
+                    "Core: supply_capacity_isone.py",
+                    _rdp_permalink("utils/pre/marginal_costs/supply_capacity_isone.py"),
+                    "FCA price resolution and capacity exceedance allocation.",
+                ],
+                [
+                    "Core: supply_ancillary.py",
+                    _rdp_permalink("utils/pre/marginal_costs/supply_ancillary.py"),
+                    "Ancillary regulation price loading.",
+                ],
+            ]
+        ),
         [
             "Core: bulk_tx_isone.py",
             _rdp_permalink("utils/pre/marginal_costs/bulk_tx_isone.py"),
@@ -329,40 +350,60 @@ def _write_readme(wb: Workbook) -> None:
             _rdp_permalink("data/eia/hourly_loads/aggregate_eia_utility_loads.py"),
             "Aggregates raw EIA zone loads into utility-level profiles.",
         ],
-        [
-            "API: ISO-NE LMP",
-            _rdp_permalink("data/isone/lmp/fetch_isone_lmp_parquet.py"),
-            'Fetches ISO-NE real-time LMP. Source: ISO NE, "ISO-NE Web Services API: Hourly Locational Marginal Prices," 2025, https://webservices.iso-ne.com/api/v1.1.',
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "API: ISO-NE LMP",
+                    _rdp_permalink("data/isone/lmp/fetch_isone_lmp_parquet.py"),
+                    'Fetches ISO-NE real-time LMP. Source: ISO NE, "ISO-NE Web Services API: Hourly Locational Marginal Prices," 2025, https://webservices.iso-ne.com/api/v1.1.',
+                ],
+            ]
+        ),
         [
             "API: ISO-NE zone loads",
             _rdp_permalink("data/isone/hourly_demand/fetch_isone_zone_loads.py"),
             'Fetches ISO-NE 8-zone hourly demand (CELT). Source: ISO NE, "Capacity, Energy, Loads, and Transmission (CELT) Report," 2025, https://www.iso-ne.com/system-planning/system-plans-studies/celt.',
         ],
-        [
-            "API: ISO-NE ancillary prices",
-            _rdp_permalink("data/isone/ancillary/fetch_isone_ancillary_parquet.py"),
-            'Fetches ISO-NE regulation clearing prices. Source: ISO NE, "Five-Minute Regulation Clearing Prices (Final)," 2025, https://webservices.iso-ne.com/api/v1.1/fiveminutercp/final/day/.',
-        ],
-        [
-            "FCA clearing prices CSV",
-            _rdp_permalink("data/isone/capacity/fca/fca_clearing_prices.csv"),
-            'Historical FCA results. Source: ISO NE, "Forward Capacity Auction Results Report," 2024, https://www.iso-ne.com/static-assets/documents/2018/05/fca-results-report.pdf.',
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "API: ISO-NE ancillary prices",
+                    _rdp_permalink("data/isone/ancillary/fetch_isone_ancillary_parquet.py"),
+                    'Fetches ISO-NE regulation clearing prices. Source: ISO NE, "Five-Minute Regulation Clearing Prices (Final)," 2025, https://webservices.iso-ne.com/api/v1.1/fiveminutercp/final/day/.',
+                ],
+                [
+                    "FCA clearing prices CSV",
+                    _rdp_permalink("data/isone/capacity/fca/fca_clearing_prices.csv"),
+                    'Historical FCA results. Source: ISO NE, "Forward Capacity Auction Results Report," 2024, https://www.iso-ne.com/static-assets/documents/2018/05/fca-results-report.pdf.',
+                ],
+            ]
+        ),
         [
             "Methodology: RI bulk TX",
             _rdp_permalink("context/methods/marginal_costs/ri_bulk_transmission_marginal_cost.md"),
             "Documents the NE system peak exceedance method for RNS/PTF allocation.",
         ],
-        [
-            "Methodology: RI supply cost recovery",
-            _rdp_permalink("context/domain/marginal_costs/ri_supply_cost_recovery.md"),
-            "Documents supply component methodology for RI.",
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "Methodology: RI supply cost recovery",
+                    _rdp_permalink("context/domain/marginal_costs/ri_supply_cost_recovery.md"),
+                    "Documents supply component methodology for RI.",
+                ],
+            ]
+        ),
         [
             "This workbook builder",
             _reports2_permalink("reports/ri_hp_rates/testimony_response/build_marginal_costs_workbook.py"),
-            "Script that generated this workbook.",
+            "Script that generated this workbook (--delivery-only)."
+            if delivery_only
+            else "Script that generated this workbook.",
         ],
         ["", "", ""],
         # --- Sheet directory ---
@@ -378,24 +419,32 @@ def _write_readme(wb: Workbook) -> None:
             "8760 rows: NE system load, rank, exceedance weight, and bulk TX MC per kWh. Top 100 hours are non-zero.",
             "",
         ],
-        [
-            "mc_supply_energy",
-            "8760 rows: RI zone LMP ($/MWh) and supply energy MC (= LMP / 1000).",
-            "",
-        ],
-        [
-            "mc_supply_capacity",
-            "8760 rows: SENE aggregate load, rank, exceedance weight, and supply capacity MC. Top 100 hours non-zero.",
-            "",
-        ],
-        [
-            "mc_supply_ancillary",
-            "8760 rows: regulation service + capacity prices, and supply ancillary MC (= sum / 1000).",
-            "",
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "mc_supply_energy",
+                    "8760 rows: RI zone LMP ($/MWh) and supply energy MC (= LMP / 1000).",
+                    "",
+                ],
+                [
+                    "mc_supply_capacity",
+                    "8760 rows: SENE aggregate load, rank, exceedance weight, and supply capacity MC. Top 100 hours non-zero.",
+                    "",
+                ],
+                [
+                    "mc_supply_ancillary",
+                    "8760 rows: regulation service + capacity prices, and supply ancillary MC (= sum / 1000).",
+                    "",
+                ],
+            ]
+        ),
         [
             "mc_combined",
-            "8760 rows joining all 5 components: delivery total, supply total, grand total MC per kWh.",
+            "8760 rows joining delivery components: dist/sub-TX + bulk TX."
+            if delivery_only
+            else "8760 rows joining all 5 components: delivery total, supply total, grand total MC per kWh.",
             "",
         ],
         ["validation", "Formula-level checks: weight sums, annual cost totals, non-zero hour counts.", ""],
@@ -412,24 +461,35 @@ def _write_readme(wb: Workbook) -> None:
             SUB_TX_AND_DIST_MC_KW_YR_2025,
             'AESC 2024 dist $80.24/kW-yr (2019$) x CPI 2025/2019. Sources: Synapse, "AESC in New England: 2024 Report," 2024; U.S. BLS, "Consumer Price Index (CUUR0000SA0)," 2025, https://fred.stlouisfed.org/series/CUUR0000SA0.',
         ],
-        [
-            "fca_sene_blended_kw_yr ($/kW-yr)",
-            FCA_SENE_BLENDED_KW_YR,
-            'FCA15 SENE $3.980 x 5mo + FCA16 SENE $2.639 x 7mo. Source: ISO NE, "Forward Capacity Auction Results Report," 2024.',
-        ],
+        *(
+            []
+            if delivery_only
+            else [
+                [
+                    "fca_sene_blended_kw_yr ($/kW-yr)",
+                    FCA_SENE_BLENDED_KW_YR,
+                    'FCA15 SENE $3.980 x 5mo + FCA16 SENE $2.639 x 7mo. Source: ISO NE, "Forward Capacity Auction Results Report," 2024.',
+                ],
+            ]
+        ),
         ["n_peak_hours", N_PEAK_HOURS, "Convention: top 100 hours for all peak-driven allocations."],
     ]
     for r in rows:
         ws.append(r)
     ws["A1"].font = Font(bold=True, size=14)
-    # Bold section headers
-    for header_row in (3, 27, 37):
-        _header_fill(ws, header_row, 3)
+    # Bold section headers — find them dynamically since row count varies
+    bold_rows = []
+    for row_idx, row_data in enumerate(rows, start=1):
+        if row_data and row_data[0] in ("Item", "Sheet", "Key scalar inputs (also live in inputs_scalars)"):
+            _header_fill(ws, row_idx, 3)
+            bold_rows.append(row_idx)
+    _README_BOLD_ROWS.clear()
+    _README_BOLD_ROWS.extend(bold_rows)
     _autosize(ws, {"A": 44, "B": 80, "C": 80})
     ws.sheet_view.showGridLines = False
 
 
-def _write_inputs_scalars(wb: Workbook) -> None:
+def _write_inputs_scalars(wb: Workbook, *, delivery_only: bool = False) -> None:
     ws = wb.create_sheet("inputs_scalars")
     rows = [
         ["key", "value", "source", "notes"],
@@ -445,19 +505,24 @@ def _write_inputs_scalars(wb: Workbook) -> None:
             _rdp_permalink("rate_design/hp_rates/ri/config/marginal_costs/ri_marginal_costs_2025.csv"),
             'AESC 2024 dist $80.24 (2019$) adjusted to 2025$ via CPIAUCSL. Sources: Synapse, "AESC in New England: 2024 Report," 2024; U.S. BLS, "Consumer Price Index (CUUR0000SA0)," 2025, https://fred.stlouisfed.org/series/CUUR0000SA0.',
         ],
-        [
-            "fca_sene_blended_kw_yr",
-            FCA_SENE_BLENDED_KW_YR,
-            _rdp_permalink("data/isone/capacity/fca/fca_clearing_prices.csv"),
-            'Calendar-year 2025 blended: FCA15 SENE $3.980/kW-mo x 5 + FCA16 SENE $2.639/kW-mo x 7 = $38.373/kW-yr. Source: ISO NE, "Forward Capacity Auction Results Report," 2024.',
-        ],
+    ]
+    if not delivery_only:
+        rows.append(
+            [
+                "fca_sene_blended_kw_yr",
+                FCA_SENE_BLENDED_KW_YR,
+                _rdp_permalink("data/isone/capacity/fca/fca_clearing_prices.csv"),
+                'Calendar-year 2025 blended: FCA15 SENE $3.980/kW-mo x 5 + FCA16 SENE $2.639/kW-mo x 7 = $38.373/kW-yr. Source: ISO NE, "Forward Capacity Auction Results Report," 2024.',
+            ]
+        )
+    rows.append(
         [
             "n_peak_hours",
             N_PEAK_HOURS,
             _rdp_permalink("utils/pre/marginal_costs/supply_utils.py"),
             "Top-N hours for exceedance and PoP allocation (consistent across all peak-driven components).",
-        ],
-    ]
+        ]
+    )
     for r in rows:
         ws.append(r)
     _header_fill(ws, 1, 4)
@@ -477,7 +542,7 @@ def _rank_load(load_df: pl.DataFrame) -> pl.DataFrame:
     return load_df.join(rank, on="timestamp", how="left").sort("timestamp")
 
 
-def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame) -> None:
+def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame, *, ref_n_peak: str = REF_N_PEAK) -> None:
     """Dist & sub-TX: PoP top-100 on RIE utility load."""
     ws = wb.create_sheet("mc_dist_sub_tx")
     headers = [
@@ -500,11 +565,11 @@ def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame) -> None:
             ws.cell(row=i, column=2, value=float(row["load_mw"]))
         if row["rank"] is not None:
             ws.cell(row=i, column=3, value=int(row["rank"]))
-        ws.cell(row=i, column=4, value=f"=IF(ISNUMBER(C{i}),C{i}<={REF_N_PEAK},FALSE)")
+        ws.cell(row=i, column=4, value=f"=IF(ISNUMBER(C{i}),C{i}<={ref_n_peak},FALSE)")
         ws.cell(
             row=i,
             column=5,
-            value=f"=IFERROR(IF(D{i},B{i}/SUMPRODUCT(($C$2:$C$8761<={REF_N_PEAK})*IFERROR($B$2:$B$8761,0)),0),0)",
+            value=f"=IFERROR(IF(D{i},B{i}/SUMPRODUCT(($C$2:$C$8761<={ref_n_peak})*IFERROR($B$2:$B$8761,0)),0),0)",
         )
         ws.cell(row=i, column=6, value=f"=E{i}*{REF_SUB_TX_DIST}")
 
@@ -518,6 +583,8 @@ def _write_exceedance_tab(
     load_df: pl.DataFrame,
     cost_ref: str,
     mc_label: str,
+    *,
+    ref_n_peak: str = REF_N_PEAK,
 ) -> None:
     """Generic exceedance allocation tab (used for bulk_tx and supply capacity)."""
     ws = wb.create_sheet(sheet_name)
@@ -543,13 +610,13 @@ def _write_exceedance_tab(
             ws.cell(row=i, column=2, value=float(row["load_mw"]))
         if row["rank"] is not None:
             ws.cell(row=i, column=3, value=int(row["rank"]))
-        ws.cell(row=i, column=4, value=f"=IF(ISNUMBER(C{i}),C{i}<={REF_N_PEAK},FALSE)")
-        ws.cell(row=i, column=5, value=f"=LARGE($B$2:$B$8761,{REF_N_PEAK}+1)")
+        ws.cell(row=i, column=4, value=f"=IF(ISNUMBER(C{i}),C{i}<={ref_n_peak},FALSE)")
+        ws.cell(row=i, column=5, value=f"=LARGE($B$2:$B$8761,{ref_n_peak}+1)")
         ws.cell(row=i, column=6, value=f"=IFERROR(IF(D{i},MAX(0,B{i}-E{i}),0),0)")
         ws.cell(
             row=i,
             column=7,
-            value=f"=IFERROR(IF(D{i},F{i}/SUMPRODUCT(($C$2:$C$8761<={REF_N_PEAK})*IFERROR(IF($B$2:$B$8761>E{i},$B$2:$B$8761-E{i},0),0)),0),0)",
+            value=f"=IFERROR(IF(D{i},F{i}/SUMPRODUCT(($C$2:$C$8761<={ref_n_peak})*IFERROR(IF($B$2:$B$8761>E{i},$B$2:$B$8761-E{i},0),0)),0),0)",
         )
         ws.cell(row=i, column=8, value=f"=G{i}*{cost_ref}")
 
@@ -559,7 +626,7 @@ def _write_exceedance_tab(
     )
 
 
-def _write_mc_bulk_tx(wb: Workbook, ne_load: pl.DataFrame) -> None:
+def _write_mc_bulk_tx(wb: Workbook, ne_load: pl.DataFrame, *, ref_n_peak: str = REF_N_PEAK) -> None:
     """Bulk TX: exceedance top-100 on NE system load."""
     _write_exceedance_tab(
         wb,
@@ -568,6 +635,7 @@ def _write_mc_bulk_tx(wb: Workbook, ne_load: pl.DataFrame) -> None:
         ne_load,
         cost_ref=REF_AESC_PTF,
         mc_label="mc_bulk_tx_per_kwh",
+        ref_n_peak=ref_n_peak,
     )
 
 
@@ -628,60 +696,60 @@ def _write_mc_supply_ancillary(wb: Workbook, ancillary_df: pl.DataFrame) -> None
     _autosize(ws, {"A": 18, "B": 16, "C": 16, "D": 26})
 
 
-def _write_mc_combined(wb: Workbook) -> None:
-    """Combined tab: cross-sheet references summing the 5 components."""
+def _write_mc_combined(wb: Workbook, *, delivery_only: bool = False) -> None:
+    """Combined tab: cross-sheet references summing components."""
     ws = wb.create_sheet("mc_combined")
-    headers = [
-        "timestamp",
-        "mc_dist_sub_tx",
-        "mc_bulk_tx",
-        "mc_supply_energy",
-        "mc_supply_capacity",
-        "mc_supply_ancillary",
-        "mc_delivery_total",
-        "mc_supply_total",
-        "mc_total",
-    ]
-    ws.append(headers)
-    _header_fill(ws, 1, len(headers))
-    ws.freeze_panes = "A2"
 
-    for i in range(2, 8762):
-        # Timestamp from dist_sub_tx tab
-        ws.cell(row=i, column=1, value=f"=mc_dist_sub_tx!A{i}")
-        # Individual components
-        ws.cell(row=i, column=2, value=f"=mc_dist_sub_tx!F{i}")
-        ws.cell(row=i, column=3, value=f"=mc_bulk_tx!H{i}")
-        ws.cell(row=i, column=4, value=f"=mc_supply_energy!C{i}")
-        ws.cell(row=i, column=5, value=f"=mc_supply_capacity!H{i}")
-        ws.cell(row=i, column=6, value=f"=mc_supply_ancillary!D{i}")
-        # Aggregates
-        ws.cell(row=i, column=7, value=f"=B{i}+C{i}")  # delivery total
-        ws.cell(row=i, column=8, value=f"=D{i}+E{i}+F{i}")  # supply total
-        ws.cell(row=i, column=9, value=f"=G{i}+H{i}")  # grand total
-
-    _autosize(
-        ws,
-        {
-            "A": 18,
-            "B": 16,
-            "C": 14,
-            "D": 18,
-            "E": 18,
-            "F": 20,
-            "G": 18,
-            "H": 16,
-            "I": 12,
-        },
-    )
+    if delivery_only:
+        headers = ["timestamp", "mc_dist_sub_tx", "mc_bulk_tx", "mc_delivery_total"]
+        ws.append(headers)
+        _header_fill(ws, 1, len(headers))
+        ws.freeze_panes = "A2"
+        for i in range(2, 8762):
+            ws.cell(row=i, column=1, value=f"=mc_dist_sub_tx!A{i}")
+            ws.cell(row=i, column=2, value=f"=mc_dist_sub_tx!F{i}")
+            ws.cell(row=i, column=3, value=f"=mc_bulk_tx!H{i}")
+            ws.cell(row=i, column=4, value=f"=B{i}+C{i}")
+        _autosize(ws, {"A": 18, "B": 16, "C": 14, "D": 18})
+    else:
+        headers = [
+            "timestamp",
+            "mc_dist_sub_tx",
+            "mc_bulk_tx",
+            "mc_supply_energy",
+            "mc_supply_capacity",
+            "mc_supply_ancillary",
+            "mc_delivery_total",
+            "mc_supply_total",
+            "mc_total",
+        ]
+        ws.append(headers)
+        _header_fill(ws, 1, len(headers))
+        ws.freeze_panes = "A2"
+        for i in range(2, 8762):
+            ws.cell(row=i, column=1, value=f"=mc_dist_sub_tx!A{i}")
+            ws.cell(row=i, column=2, value=f"=mc_dist_sub_tx!F{i}")
+            ws.cell(row=i, column=3, value=f"=mc_bulk_tx!H{i}")
+            ws.cell(row=i, column=4, value=f"=mc_supply_energy!C{i}")
+            ws.cell(row=i, column=5, value=f"=mc_supply_capacity!H{i}")
+            ws.cell(row=i, column=6, value=f"=mc_supply_ancillary!D{i}")
+            ws.cell(row=i, column=7, value=f"=B{i}+C{i}")
+            ws.cell(row=i, column=8, value=f"=D{i}+E{i}+F{i}")
+            ws.cell(row=i, column=9, value=f"=G{i}+H{i}")
+        _autosize(
+            ws,
+            {"A": 18, "B": 16, "C": 14, "D": 18, "E": 18, "F": 20, "G": 18, "H": 16, "I": 12},
+        )
 
 
-def _write_validation(wb: Workbook) -> None:
+def _write_validation(wb: Workbook, *, delivery_only: bool = False) -> None:
     """Validation tab: formula-level checks on weight sums and annual totals."""
     ws = wb.create_sheet("validation")
     headers = ["check", "actual", "expected", "abs_error", "tolerance", "ok"]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
+
+    ref_n = REF_N_PEAK_DELIVERY_ONLY if delivery_only else REF_N_PEAK
 
     checks = [
         (
@@ -709,36 +777,42 @@ def _write_validation(wb: Workbook) -> None:
             0.01,
         ),
         (
-            "sum(exceedance_weight) for capacity = 1.0",
-            "=SUM(mc_supply_capacity!G$2:G$8761)",
-            "=1",
-            1e-6,
-        ),
-        (
-            "sum(mc_supply_capacity_per_kwh) = fca_blended_kw_yr",
-            "=SUM(mc_supply_capacity!H$2:H$8761)",
-            f"={REF_FCA_BLENDED}",
-            0.01,
-        ),
-        (
             "non-zero hours dist_sub_tx = 100",
             '=COUNTIF(mc_dist_sub_tx!F$2:F$8761,">0")',
-            f"={REF_N_PEAK}",
+            f"={ref_n}",
             0,
         ),
         (
             "non-zero hours bulk_tx = 100",
             '=COUNTIF(mc_bulk_tx!H$2:H$8761,">0")',
-            f"={REF_N_PEAK}",
-            0,
-        ),
-        (
-            "non-zero hours capacity = 100",
-            '=COUNTIF(mc_supply_capacity!H$2:H$8761,">0")',
-            f"={REF_N_PEAK}",
+            f"={ref_n}",
             0,
         ),
     ]
+
+    if not delivery_only:
+        checks.extend(
+            [
+                (
+                    "sum(exceedance_weight) for capacity = 1.0",
+                    "=SUM(mc_supply_capacity!G$2:G$8761)",
+                    "=1",
+                    1e-6,
+                ),
+                (
+                    "sum(mc_supply_capacity_per_kwh) = fca_blended_kw_yr",
+                    "=SUM(mc_supply_capacity!H$2:H$8761)",
+                    f"={REF_FCA_BLENDED}",
+                    0.01,
+                ),
+                (
+                    "non-zero hours capacity = 100",
+                    '=COUNTIF(mc_supply_capacity!H$2:H$8761,">0")',
+                    f"={ref_n}",
+                    0,
+                ),
+            ]
+        )
 
     for i, (name, actual, expected, tol) in enumerate(checks, start=2):
         ws.cell(row=i, column=1, value=name)
@@ -849,22 +923,30 @@ def _validate_mc_against_parquets(
     _check("supply_ancillary", anc_derived, load_supply_ancillary_parquet())
 
 
-def build_workbook(output_path: Path) -> Path:
+def build_workbook(output_path: Path, *, delivery_only: bool = False) -> Path:
     """Build and save the .xlsx workbook. Returns the output path."""
+    mode = "delivery-only" if delivery_only else "full (5-component)"
+    print(f"Building {mode} marginal cost workbook ...", flush=True)
+
     print("Loading raw ISO-NE / EIA data from S3 ...", flush=True)
     rie_load = load_rie_hourly_load()
     print(f"  RIE utility load: {rie_load.height} hours", flush=True)
     ne_load = load_ne_system_load()
     print(f"  NE system load: {ne_load.height} hours", flush=True)
-    sene_load = load_sene_load()
-    print(f"  SENE aggregate load: {sene_load.height} hours", flush=True)
-    lmp_df = load_ri_lmp()
-    print(f"  RI zone LMP: {lmp_df.height} hours", flush=True)
-    ancillary_df = load_ancillary_prices()
-    print(f"  Ancillary prices: {ancillary_df.height} hours", flush=True)
+
+    if not delivery_only:
+        sene_load = load_sene_load()
+        print(f"  SENE aggregate load: {sene_load.height} hours", flush=True)
+        lmp_df = load_ri_lmp()
+        print(f"  RI zone LMP: {lmp_df.height} hours", flush=True)
+        ancillary_df = load_ancillary_prices()
+        print(f"  Ancillary prices: {ancillary_df.height} hours", flush=True)
 
     print("Validating derivation against MC parquets passed to CAIRO ...", flush=True)
-    _validate_mc_against_parquets(rie_load, ne_load, sene_load, lmp_df, ancillary_df)
+    if delivery_only:
+        _validate_delivery_only(rie_load, ne_load)
+    else:
+        _validate_mc_against_parquets(rie_load, ne_load, sene_load, lmp_df, ancillary_df)
 
     print("Building workbook ...", flush=True)
     wb = Workbook()
@@ -872,20 +954,44 @@ def build_workbook(output_path: Path) -> Path:
     if default is not None:
         wb.remove(default)
 
-    _write_readme(wb)
-    _write_inputs_scalars(wb)
-    _write_mc_dist_sub_tx(wb, rie_load)
-    _write_mc_bulk_tx(wb, ne_load)
-    _write_mc_supply_energy(wb, lmp_df)
-    _write_mc_supply_capacity(wb, sene_load)
-    _write_mc_supply_ancillary(wb, ancillary_df)
-    _write_mc_combined(wb)
-    _write_validation(wb)
+    ref_n = REF_N_PEAK_DELIVERY_ONLY if delivery_only else REF_N_PEAK
+    _write_readme(wb, delivery_only=delivery_only)
+    _write_inputs_scalars(wb, delivery_only=delivery_only)
+    _write_mc_dist_sub_tx(wb, rie_load, ref_n_peak=ref_n)
+    _write_mc_bulk_tx(wb, ne_load, ref_n_peak=ref_n)
+    if not delivery_only:
+        _write_mc_supply_energy(wb, lmp_df)
+        _write_mc_supply_capacity(wb, sene_load)
+        _write_mc_supply_ancillary(wb, ancillary_df)
+    _write_mc_combined(wb, delivery_only=delivery_only)
+    _write_validation(wb, delivery_only=delivery_only)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     wb.save(str(output_path))
     print(f"Wrote {output_path} ({output_path.stat().st_size / 1024:.1f} KB)", flush=True)
     return output_path
+
+
+def _validate_delivery_only(rie_load: pl.DataFrame, ne_load: pl.DataFrame) -> None:
+    """Validate only the two delivery MC components against parquets."""
+    tol = 1e-4
+
+    def _check(name: str, derived: pl.DataFrame, parquet: pl.DataFrame) -> None:
+        joined = derived.join(parquet, on="timestamp", how="inner").sort("timestamp")
+        max_err = float((joined["mc_derived"] - joined["mc_value"]).abs().max())  # type: ignore[arg-type]
+        assert max_err < tol, f"{name}: max hourly error = {max_err:.2e} (tol = {tol:.0e})"
+        print(f"  {name}: PASS (max error = {max_err:.2e})", flush=True)
+
+    _check(
+        "dist_sub_tx",
+        _derive_pop_mc(rie_load, SUB_TX_AND_DIST_MC_KW_YR_2025, N_PEAK_HOURS),
+        load_dist_sub_tx_parquet(),
+    )
+    _check(
+        "bulk_tx",
+        _derive_exceedance_mc(ne_load, AESC_PTF_KW_YEAR, N_PEAK_HOURS),
+        load_bulk_tx_parquet(),
+    )
 
 
 # ── Formatting & upload ───────────────────────────────────────────────────────
@@ -896,7 +1002,6 @@ _TAB_FORMATTING: dict[str, dict] = {
         "column_widths_px": {"A": 300, "B": 540, "C": 540},
         "freeze_rows": 1,
         "bold_header": True,
-        "bold_rows": [3, 27, 37],
     },
     "inputs_scalars": {
         "column_number_formats": {"B": "#,##0.000"},
@@ -992,7 +1097,10 @@ def upload_to_sheet(xlsx_path: Path, spreadsheet_id: str) -> None:
     for ws in spreadsheet.worksheets():
         spec = _TAB_FORMATTING.get(ws.title)
         if spec:
-            apply_sheet_formatting(ws, **spec)
+            fmt = dict(spec)
+            if ws.title == "README" and _README_BOLD_ROWS:
+                fmt["bold_rows"] = list(_README_BOLD_ROWS)
+            apply_sheet_formatting(ws, **fmt)
     print(
         f"Done. View at https://docs.google.com/spreadsheets/d/{spreadsheet_id}/edit",
         flush=True,
@@ -1004,8 +1112,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("cache/marginal_costs_rie_2025.xlsx"),
-        help="Output .xlsx path. Default: cache/marginal_costs_rie_2025.xlsx",
+        default=None,
+        help="Output .xlsx path. Defaults depend on --delivery-only.",
     )
     parser.add_argument(
         "--upload",
@@ -1014,12 +1122,26 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--spreadsheet-id",
-        default=DEFAULT_SPREADSHEET_ID,
-        help=f"Override the upload target Sheet id. Default: {DEFAULT_SPREADSHEET_ID}",
+        default=None,
+        help="Override the upload target Sheet id.",
+    )
+    parser.add_argument(
+        "--delivery-only",
+        action="store_true",
+        help="Only include delivery MCs (dist/sub-TX + bulk TX). Omit supply tabs.",
     )
     args = parser.parse_args(argv)
 
-    out = build_workbook(args.output)
+    if args.output is None:
+        args.output = (
+            Path("cache/marginal_costs_rie_2025_delivery.xlsx")
+            if args.delivery_only
+            else Path("cache/marginal_costs_rie_2025.xlsx")
+        )
+    if args.spreadsheet_id is None:
+        args.spreadsheet_id = DELIVERY_ONLY_SPREADSHEET_ID if args.delivery_only else DEFAULT_SPREADSHEET_ID
+
+    out = build_workbook(args.output, delivery_only=args.delivery_only)
     if args.upload:
         upload_to_sheet(out, args.spreadsheet_id)
     return 0

--- a/reports/ri_hp_rates/testimony_response/build_marginal_costs_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/build_marginal_costs_workbook.py
@@ -322,7 +322,7 @@ def _write_readme(wb: Workbook) -> None:
         [
             "API: EIA hourly utility loads",
             _rdp_permalink("data/eia/hourly_loads/fetch_zone_loads_parquet.py"),
-            "Fetches EIA-930 hourly demand by utility. @eia_HourlyElectricGridMonitor_2025.",
+            'Fetches EIA-930 hourly demand by utility. Source: EIA, "Hourly Electric Grid Monitor (Form EIA-930)," 2025, https://www.eia.gov/electricity/gridmonitor/.',
         ],
         [
             "API: EIA utility load aggregation",
@@ -332,22 +332,22 @@ def _write_readme(wb: Workbook) -> None:
         [
             "API: ISO-NE LMP",
             _rdp_permalink("data/isone/lmp/fetch_isone_lmp_parquet.py"),
-            "Fetches ISO-NE real-time LMP. @isone_ISONEWebServices_2025.",
+            'Fetches ISO-NE real-time LMP. Source: ISO NE, "ISO-NE Web Services API: Hourly Locational Marginal Prices," 2025, https://webservices.iso-ne.com/api/v1.1.',
         ],
         [
             "API: ISO-NE zone loads",
             _rdp_permalink("data/isone/hourly_demand/fetch_isone_zone_loads.py"),
-            "Fetches ISO-NE 8-zone hourly demand (CELT). @isone_CeltReport_2025.",
+            'Fetches ISO-NE 8-zone hourly demand (CELT). Source: ISO NE, "Capacity, Energy, Loads, and Transmission (CELT) Report," 2025, https://www.iso-ne.com/system-planning/system-plans-studies/celt.',
         ],
         [
             "API: ISO-NE ancillary prices",
             _rdp_permalink("data/isone/ancillary/fetch_isone_ancillary_parquet.py"),
-            "Fetches ISO-NE regulation clearing prices. @iso-ne_RegulationClearingPrices_2025.",
+            'Fetches ISO-NE regulation clearing prices. Source: ISO NE, "Five-Minute Regulation Clearing Prices (Final)," 2025, https://webservices.iso-ne.com/api/v1.1/fiveminutercp/final/day/.',
         ],
         [
             "FCA clearing prices CSV",
             _rdp_permalink("data/isone/capacity/fca/fca_clearing_prices.csv"),
-            "Historical FCA results. @isone_ForwardCapacityAuction_2024.",
+            'Historical FCA results. Source: ISO NE, "Forward Capacity Auction Results Report," 2024, https://www.iso-ne.com/static-assets/documents/2018/05/fca-results-report.pdf.',
         ],
         [
             "Methodology: RI bulk TX",
@@ -405,17 +405,17 @@ def _write_readme(wb: Workbook) -> None:
         [
             "aesc_ptf_kw_year ($/kW-yr)",
             AESC_PTF_KW_YEAR,
-            "AESC 2024 avoided PTF. @synapse_AvoidedEnergySupply_2024.",
+            'AESC 2024 avoided PTF. Source: Synapse, "Avoided Energy Supply Components (AESC) in New England: 2024 Report," 2024.',
         ],
         [
             "sub_tx_and_dist_mc_kw_yr ($/kW-yr, 2025$)",
             SUB_TX_AND_DIST_MC_KW_YR_2025,
-            "AESC 2024 dist $80.24/kW-yr (2019$) x CPI 2025/2019. @synapse_AvoidedEnergySupply_2024 + @fred_ConsumerPriceIndexAll_2025.",
+            'AESC 2024 dist $80.24/kW-yr (2019$) x CPI 2025/2019. Sources: Synapse, "AESC in New England: 2024 Report," 2024; U.S. BLS, "Consumer Price Index (CUUR0000SA0)," 2025, https://fred.stlouisfed.org/series/CUUR0000SA0.',
         ],
         [
             "fca_sene_blended_kw_yr ($/kW-yr)",
             FCA_SENE_BLENDED_KW_YR,
-            "FCA15 SENE $3.980 x 5mo + FCA16 SENE $2.639 x 7mo. @isone_ForwardCapacityAuction_2024.",
+            'FCA15 SENE $3.980 x 5mo + FCA16 SENE $2.639 x 7mo. Source: ISO NE, "Forward Capacity Auction Results Report," 2024.',
         ],
         ["n_peak_hours", N_PEAK_HOURS, "Convention: top 100 hours for all peak-driven allocations."],
     ]
@@ -437,19 +437,19 @@ def _write_inputs_scalars(wb: Workbook) -> None:
             "aesc_ptf_kw_year",
             AESC_PTF_KW_YEAR,
             _rdp_permalink("utils/pre/marginal_costs/bulk_tx_isone.py"),
-            "AESC 2024 avoided PTF ($/kW-yr). Synapse Energy Economics. @synapse_AvoidedEnergySupply_2024.",
+            'AESC 2024 avoided PTF ($/kW-yr). Source: Synapse, "Avoided Energy Supply Components (AESC) in New England: 2024 Report," 2024.',
         ],
         [
             "sub_tx_and_dist_mc_kw_yr",
             SUB_TX_AND_DIST_MC_KW_YR_2025,
             _rdp_permalink("rate_design/hp_rates/ri/config/marginal_costs/ri_marginal_costs_2025.csv"),
-            "AESC 2024 dist $80.24 (2019$) adjusted to 2025$ via CPIAUCSL. @synapse_AvoidedEnergySupply_2024 + @fred_ConsumerPriceIndexAll_2025.",
+            'AESC 2024 dist $80.24 (2019$) adjusted to 2025$ via CPIAUCSL. Sources: Synapse, "AESC in New England: 2024 Report," 2024; U.S. BLS, "Consumer Price Index (CUUR0000SA0)," 2025, https://fred.stlouisfed.org/series/CUUR0000SA0.',
         ],
         [
             "fca_sene_blended_kw_yr",
             FCA_SENE_BLENDED_KW_YR,
             _rdp_permalink("data/isone/capacity/fca/fca_clearing_prices.csv"),
-            "Calendar-year 2025 blended: FCA15 SENE $3.980/kW-mo x 5 + FCA16 SENE $2.639/kW-mo x 7 = $38.373/kW-yr. @isone_ForwardCapacityAuction_2024.",
+            'Calendar-year 2025 blended: FCA15 SENE $3.980/kW-mo x 5 + FCA16 SENE $2.639/kW-mo x 7 = $38.373/kW-yr. Source: ISO NE, "Forward Capacity Auction Results Report," 2024.',
         ],
         [
             "n_peak_hours",
@@ -465,24 +465,19 @@ def _write_inputs_scalars(wb: Workbook) -> None:
     ws.sheet_view.showGridLines = False
 
 
-def _join_mc_with_load(mc_parquet: pl.DataFrame, load_df: pl.DataFrame) -> pl.DataFrame:
-    """Left-join load_df onto the MC parquet's 8760 grid.
-
-    Computes a rank over rows where load_mw is non-null. Missing hours (DST
-    gaps in raw data) are left as null and rendered blank in the workbook.
-    """
-    df = mc_parquet.join(load_df, on="timestamp", how="left")
+def _rank_load(load_df: pl.DataFrame) -> pl.DataFrame:
+    """Rank load hours descending. Missing hours left as null."""
     rank = (
-        df.filter(pl.col("load_mw").is_not_null())
+        load_df.filter(pl.col("load_mw").is_not_null())
         .sort("load_mw", descending=True)
         .with_row_index("rank_0")
         .with_columns((pl.col("rank_0") + 1).cast(pl.Int32).alias("rank"))
         .select("timestamp", "rank")
     )
-    return df.join(rank, on="timestamp", how="left").sort("timestamp")
+    return load_df.join(rank, on="timestamp", how="left").sort("timestamp")
 
 
-def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame, mc_parquet: pl.DataFrame) -> None:
+def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame) -> None:
     """Dist & sub-TX: PoP top-100 on RIE utility load."""
     ws = wb.create_sheet("mc_dist_sub_tx")
     headers = [
@@ -492,13 +487,12 @@ def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame, mc_parquet: pl.D
         "is_peak_top100",
         "pop_weight",
         "mc_dist_sub_tx_per_kwh",
-        "mc_parquet_value",
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
     ws.freeze_panes = "A2"
 
-    joined = _join_mc_with_load(mc_parquet, rie_load)
+    joined = _rank_load(rie_load)
 
     for i, row in enumerate(joined.iter_rows(named=True), start=2):
         ws.cell(row=i, column=1, value=row["timestamp"].strftime("%Y-%m-%d %H:%M"))
@@ -513,10 +507,8 @@ def _write_mc_dist_sub_tx(wb: Workbook, rie_load: pl.DataFrame, mc_parquet: pl.D
             value=f"=IFERROR(IF(D{i},B{i}/SUMPRODUCT(($C$2:$C$8761<={REF_N_PEAK})*IFERROR($B$2:$B$8761,0)),0),0)",
         )
         ws.cell(row=i, column=6, value=f"=E{i}*{REF_SUB_TX_DIST}")
-        mc_val = row["mc_value"]
-        ws.cell(row=i, column=7, value=float(mc_val) if mc_val is not None else 0.0)
 
-    _autosize(ws, {"A": 18, "B": 14, "C": 8, "D": 14, "E": 14, "F": 22, "G": 18})
+    _autosize(ws, {"A": 18, "B": 14, "C": 8, "D": 14, "E": 14, "F": 22})
 
 
 def _write_exceedance_tab(
@@ -524,7 +516,6 @@ def _write_exceedance_tab(
     sheet_name: str,
     load_label: str,
     load_df: pl.DataFrame,
-    mc_parquet: pl.DataFrame,
     cost_ref: str,
     mc_label: str,
 ) -> None:
@@ -539,13 +530,12 @@ def _write_exceedance_tab(
         "exceedance",
         "exceedance_weight",
         mc_label,
-        "mc_parquet_value",
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
     ws.freeze_panes = "A2"
 
-    joined = _join_mc_with_load(mc_parquet, load_df)
+    joined = _rank_load(load_df)
 
     for i, row in enumerate(joined.iter_rows(named=True), start=2):
         ws.cell(row=i, column=1, value=row["timestamp"].strftime("%Y-%m-%d %H:%M"))
@@ -562,63 +552,57 @@ def _write_exceedance_tab(
             value=f"=IFERROR(IF(D{i},F{i}/SUMPRODUCT(($C$2:$C$8761<={REF_N_PEAK})*IFERROR(IF($B$2:$B$8761>E{i},$B$2:$B$8761-E{i},0),0)),0),0)",
         )
         ws.cell(row=i, column=8, value=f"=G{i}*{cost_ref}")
-        mc_val = row["mc_value"]
-        ws.cell(row=i, column=9, value=float(mc_val) if mc_val is not None else 0.0)
 
     _autosize(
         ws,
-        {"A": 18, "B": 18, "C": 8, "D": 14, "E": 20, "F": 14, "G": 16, "H": 24, "I": 18},
+        {"A": 18, "B": 18, "C": 8, "D": 14, "E": 20, "F": 14, "G": 16, "H": 24},
     )
 
 
-def _write_mc_bulk_tx(wb: Workbook, ne_load: pl.DataFrame, mc_parquet: pl.DataFrame) -> None:
+def _write_mc_bulk_tx(wb: Workbook, ne_load: pl.DataFrame) -> None:
     """Bulk TX: exceedance top-100 on NE system load."""
     _write_exceedance_tab(
         wb,
         "mc_bulk_tx",
         "ne_system_load_mw",
         ne_load,
-        mc_parquet,
         cost_ref=REF_AESC_PTF,
         mc_label="mc_bulk_tx_per_kwh",
     )
 
 
-def _write_mc_supply_energy(wb: Workbook, lmp_df: pl.DataFrame, mc_parquet: pl.DataFrame) -> None:
+def _write_mc_supply_energy(wb: Workbook, lmp_df: pl.DataFrame) -> None:
     """Supply energy: LMP / 1000."""
     ws = wb.create_sheet("mc_supply_energy")
-    headers = ["timestamp", "ri_zone_lmp_mwh", "mc_supply_energy_per_kwh", "mc_parquet_value"]
+    headers = ["timestamp", "ri_zone_lmp_mwh", "mc_supply_energy_per_kwh"]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
     ws.freeze_panes = "A2"
 
-    joined = mc_parquet.join(lmp_df, on="timestamp", how="left").sort("timestamp")
+    lmp_sorted = lmp_df.sort("timestamp")
 
-    for i, row in enumerate(joined.iter_rows(named=True), start=2):
+    for i, row in enumerate(lmp_sorted.iter_rows(named=True), start=2):
         ws.cell(row=i, column=1, value=row["timestamp"].strftime("%Y-%m-%d %H:%M"))
         if row["lmp_usd_per_mwh"] is not None:
             ws.cell(row=i, column=2, value=float(row["lmp_usd_per_mwh"]))
         ws.cell(row=i, column=3, value=f"=IFERROR(B{i}/1000,0)")
-        mc_val = row["mc_value"]
-        ws.cell(row=i, column=4, value=float(mc_val) if mc_val is not None else 0.0)
 
-    _autosize(ws, {"A": 18, "B": 18, "C": 24, "D": 18})
+    _autosize(ws, {"A": 18, "B": 18, "C": 24})
 
 
-def _write_mc_supply_capacity(wb: Workbook, sene_load: pl.DataFrame, mc_parquet: pl.DataFrame) -> None:
+def _write_mc_supply_capacity(wb: Workbook, sene_load: pl.DataFrame) -> None:
     """Supply capacity: FCA exceedance top-100 on SENE load."""
     _write_exceedance_tab(
         wb,
         "mc_supply_capacity",
         "sene_load_mw",
         sene_load,
-        mc_parquet,
         cost_ref=REF_FCA_BLENDED,
         mc_label="mc_supply_capacity_per_kwh",
     )
 
 
-def _write_mc_supply_ancillary(wb: Workbook, ancillary_df: pl.DataFrame, mc_parquet: pl.DataFrame) -> None:
+def _write_mc_supply_ancillary(wb: Workbook, ancillary_df: pl.DataFrame) -> None:
     """Supply ancillary: (reg_service + reg_capacity) / 1000."""
     ws = wb.create_sheet("mc_supply_ancillary")
     headers = [
@@ -626,25 +610,22 @@ def _write_mc_supply_ancillary(wb: Workbook, ancillary_df: pl.DataFrame, mc_parq
         "reg_service_mwh",
         "reg_capacity_mwh",
         "mc_supply_ancillary_per_kwh",
-        "mc_parquet_value",
     ]
     ws.append(headers)
     _header_fill(ws, 1, len(headers))
     ws.freeze_panes = "A2"
 
-    joined = mc_parquet.join(ancillary_df, on="timestamp", how="left").sort("timestamp")
+    anc_sorted = ancillary_df.sort("timestamp")
 
-    for i, row in enumerate(joined.iter_rows(named=True), start=2):
+    for i, row in enumerate(anc_sorted.iter_rows(named=True), start=2):
         ws.cell(row=i, column=1, value=row["timestamp"].strftime("%Y-%m-%d %H:%M"))
         if row["reg_service_price_usd_per_mwh"] is not None:
             ws.cell(row=i, column=2, value=float(row["reg_service_price_usd_per_mwh"]))
         if row["reg_capacity_price_usd_per_mwh"] is not None:
             ws.cell(row=i, column=3, value=float(row["reg_capacity_price_usd_per_mwh"]))
         ws.cell(row=i, column=4, value=f"=IFERROR((B{i}+C{i})/1000,0)")
-        mc_val = row["mc_value"]
-        ws.cell(row=i, column=5, value=float(mc_val) if mc_val is not None else 0.0)
 
-    _autosize(ws, {"A": 18, "B": 16, "C": 16, "D": 26, "E": 18})
+    _autosize(ws, {"A": 18, "B": 16, "C": 16, "D": 26})
 
 
 def _write_mc_combined(wb: Workbook) -> None:
@@ -778,16 +759,98 @@ def _write_validation(wb: Workbook) -> None:
 # ── Main build ────────────────────────────────────────────────────────────────
 
 
+def _derive_pop_mc(load_df: pl.DataFrame, annual_cost: float, n_peak: int) -> pl.DataFrame:
+    """Reproduce PoP allocation in Python (mirrors the spreadsheet formulas)."""
+    ranked = _rank_load(load_df)
+    peak = ranked.filter(pl.col("rank").is_not_null(), pl.col("rank") <= n_peak)
+    peak_load_sum = float(peak["load_mw"].sum())
+    return (
+        ranked.with_columns(
+            pl.when(pl.col("rank").is_not_null() & (pl.col("rank") <= n_peak))
+            .then(pl.col("load_mw") / peak_load_sum * annual_cost)
+            .otherwise(0.0)
+            .alias("mc_derived")
+        )
+        .select("timestamp", "mc_derived")
+        .sort("timestamp")
+    )
+
+
+def _derive_exceedance_mc(load_df: pl.DataFrame, annual_cost: float, n_peak: int) -> pl.DataFrame:
+    """Reproduce exceedance allocation in Python (mirrors the spreadsheet formulas)."""
+    ranked = _rank_load(load_df)
+    threshold = float(ranked.filter(pl.col("rank") == n_peak + 1)["load_mw"].item())
+    return (
+        ranked.with_columns(
+            pl.when(pl.col("rank").is_not_null() & (pl.col("rank") <= n_peak))
+            .then(
+                (pl.col("load_mw") - threshold).clip(lower_bound=0)
+                / (
+                    ranked.filter(pl.col("rank").is_not_null(), pl.col("rank") <= n_peak)
+                    .select((pl.col("load_mw") - threshold).clip(lower_bound=0).sum())
+                    .item()
+                )
+                * annual_cost
+            )
+            .otherwise(0.0)
+            .alias("mc_derived")
+        )
+        .select("timestamp", "mc_derived")
+        .sort("timestamp")
+    )
+
+
+def _validate_mc_against_parquets(
+    rie_load: pl.DataFrame,
+    ne_load: pl.DataFrame,
+    sene_load: pl.DataFrame,
+    lmp_df: pl.DataFrame,
+    ancillary_df: pl.DataFrame,
+) -> None:
+    """Assert that our derivation reproduces the MC parquets passed to CAIRO."""
+    tol = 1e-4
+
+    def _check(name: str, derived: pl.DataFrame, parquet: pl.DataFrame) -> None:
+        joined = derived.join(parquet, on="timestamp", how="inner").sort("timestamp")
+        max_err = float((joined["mc_derived"] - joined["mc_value"]).abs().max())  # type: ignore[arg-type]
+        assert max_err < tol, f"{name}: max hourly error = {max_err:.2e} (tol = {tol:.0e})"
+        print(f"  {name}: PASS (max error = {max_err:.2e})", flush=True)
+
+    _check(
+        "dist_sub_tx",
+        _derive_pop_mc(rie_load, SUB_TX_AND_DIST_MC_KW_YR_2025, N_PEAK_HOURS),
+        load_dist_sub_tx_parquet(),
+    )
+    _check(
+        "bulk_tx",
+        _derive_exceedance_mc(ne_load, AESC_PTF_KW_YEAR, N_PEAK_HOURS),
+        load_bulk_tx_parquet(),
+    )
+    # Supply parquets are stored in $/MWh (energy, ancillary) or scaled by
+    # 1000 (capacity), so we derive in those same native units for comparison.
+    cap_derived = _derive_exceedance_mc(sene_load, FCA_SENE_BLENDED_KW_YR, N_PEAK_HOURS)
+    cap_derived = cap_derived.with_columns(pl.col("mc_derived") * 1000.0)
+    _check("supply_capacity", cap_derived, load_supply_capacity_parquet())
+
+    energy_derived = (
+        lmp_df.sort("timestamp")
+        .with_columns(pl.col("lmp_usd_per_mwh").alias("mc_derived"))
+        .select("timestamp", "mc_derived")
+    )
+    _check("supply_energy", energy_derived, load_supply_energy_parquet())
+
+    anc_derived = (
+        ancillary_df.sort("timestamp")
+        .with_columns(
+            (pl.col("reg_service_price_usd_per_mwh") + pl.col("reg_capacity_price_usd_per_mwh")).alias("mc_derived")
+        )
+        .select("timestamp", "mc_derived")
+    )
+    _check("supply_ancillary", anc_derived, load_supply_ancillary_parquet())
+
+
 def build_workbook(output_path: Path) -> Path:
     """Build and save the .xlsx workbook. Returns the output path."""
-    print("Loading MC parquets from S3 ...", flush=True)
-    mc_dist = load_dist_sub_tx_parquet()
-    mc_bulk = load_bulk_tx_parquet()
-    mc_energy = load_supply_energy_parquet()
-    mc_capacity = load_supply_capacity_parquet()
-    mc_ancillary = load_supply_ancillary_parquet()
-    print(f"  All 5 parquets loaded ({mc_dist.height} rows each)", flush=True)
-
     print("Loading raw ISO-NE / EIA data from S3 ...", flush=True)
     rie_load = load_rie_hourly_load()
     print(f"  RIE utility load: {rie_load.height} hours", flush=True)
@@ -800,6 +863,9 @@ def build_workbook(output_path: Path) -> Path:
     ancillary_df = load_ancillary_prices()
     print(f"  Ancillary prices: {ancillary_df.height} hours", flush=True)
 
+    print("Validating derivation against MC parquets passed to CAIRO ...", flush=True)
+    _validate_mc_against_parquets(rie_load, ne_load, sene_load, lmp_df, ancillary_df)
+
     print("Building workbook ...", flush=True)
     wb = Workbook()
     default = wb.active
@@ -808,11 +874,11 @@ def build_workbook(output_path: Path) -> Path:
 
     _write_readme(wb)
     _write_inputs_scalars(wb)
-    _write_mc_dist_sub_tx(wb, rie_load, mc_dist)
-    _write_mc_bulk_tx(wb, ne_load, mc_bulk)
-    _write_mc_supply_energy(wb, lmp_df, mc_energy)
-    _write_mc_supply_capacity(wb, sene_load, mc_capacity)
-    _write_mc_supply_ancillary(wb, ancillary_df, mc_ancillary)
+    _write_mc_dist_sub_tx(wb, rie_load)
+    _write_mc_bulk_tx(wb, ne_load)
+    _write_mc_supply_energy(wb, lmp_df)
+    _write_mc_supply_capacity(wb, sene_load)
+    _write_mc_supply_ancillary(wb, ancillary_df)
     _write_mc_combined(wb)
     _write_validation(wb)
 
@@ -844,9 +910,8 @@ _TAB_FORMATTING: dict[str, dict] = {
             "B": "#,##0.0",
             "E": "0.000000",
             "F": "0.000000",
-            "G": "0.000000",
         },
-        "auto_resize_columns": ["A:G"],
+        "auto_resize_columns": ["A:F"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -857,9 +922,8 @@ _TAB_FORMATTING: dict[str, dict] = {
             "F": "#,##0.00",
             "G": "0.000000",
             "H": "0.000000",
-            "I": "0.000000",
         },
-        "auto_resize_columns": ["A:I"],
+        "auto_resize_columns": ["A:H"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -867,9 +931,8 @@ _TAB_FORMATTING: dict[str, dict] = {
         "column_number_formats": {
             "B": "#,##0.00",
             "C": "0.000000",
-            "D": "0.000000",
         },
-        "auto_resize_columns": ["A:D"],
+        "auto_resize_columns": ["A:C"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -880,9 +943,8 @@ _TAB_FORMATTING: dict[str, dict] = {
             "F": "#,##0.00",
             "G": "0.000000",
             "H": "0.000000",
-            "I": "0.000000",
         },
-        "auto_resize_columns": ["A:I"],
+        "auto_resize_columns": ["A:H"],
         "freeze_rows": 1,
         "bold_header": True,
     },
@@ -891,9 +953,8 @@ _TAB_FORMATTING: dict[str, dict] = {
             "B": "#,##0.00",
             "C": "#,##0.00",
             "D": "0.000000",
-            "E": "0.000000",
         },
-        "auto_resize_columns": ["A:E"],
+        "auto_resize_columns": ["A:D"],
         "freeze_rows": 1,
         "bold_header": True,
     },

--- a/reports/ri_hp_rates/testimony_response/context/cairo_bill_decomposition.md
+++ b/reports/ri_hp_rates/testimony_response/context/cairo_bill_decomposition.md
@@ -1,0 +1,255 @@
+# CAIRO bill decomposition: how electric bills are computed
+
+This document records findings from tracing building 184434 (upgrade 2 = heat pump)
+through the full CAIRO billing pipeline and `build_master_bills.py` post-processing.
+It explains how `elec_fixed_charge`, `elec_delivery_bill`, `elec_supply_bill`, and
+`elec_total_bill` in the master bills relate to the calibrated tariff JSONs, ResStock
+kWh, and the revenue requirement YAMLs.
+
+## Inputs
+
+### ResStock loads
+
+- Source: `/ebs/data/nrel/resstock/res_2024_amy2018_2_sb/load_curve_hourly/state=RI/upgrade=02/{bldg_id}-2.parquet`
+- 8760 hourly rows per building, actual meteorological year 2018 (AMY2018).
+- Column: `out.electricity.total.energy_consumption` (kWh per hour).
+- Building 184434 raw annual kWh (upgrade 2): **16,112.655 kWh**.
+- PV generation for this building: **0.0 kWh** (no solar).
+
+### Calibrated tariffs (URDB JSON)
+
+All tariffs are flat (single period, single tier, no demand charges).
+
+| Tariff file                          | Volumetric rate ($/kWh) | Fixed charge ($/mo) | Used by                              |
+| ------------------------------------ | ----------------------- | ------------------- | ------------------------------------ |
+| `rie_hp_flat_calibrated.json`        | 0.08249                 | 10.01               | Run 19 (delivery)                    |
+| `rie_hp_flat_supply_calibrated.json` | 0.23129                 | 10.01               | Run 20 (delivery+supply bundled)     |
+| `rie_default_calibrated.json`        | 0.14078                 | 10.01               | Runs 1, 3 (default delivery)         |
+| `rie_default_supply_calibrated.json` | seasonal                | 10.01               | Runs 2, 4 (default supply)           |
+| `rie_flat.json`                      | —                       | **11.47**           | `build_master_bills.py` fixed charge |
+
+### Revenue requirement YAMLs
+
+| YAML                                        | Used by                              | Notes                                                           |
+| ------------------------------------------- | ------------------------------------ | --------------------------------------------------------------- |
+| `rie_rate_case_test_year.yaml`              | Runs 1–4 (precalc + default)         | Real RR; contains full budget breakdown                         |
+| `rie_large_number_rate_case_test_year.yaml` | Runs 19–20 (calibrated tariff runs)  | `revenue_requirement: 1e12` — prevents recalibration            |
+| `rie_hp_vs_nonhp_rate_case_test_year.yaml`  | Runs 17–18 (precalc for HP subclass) | HP subclass calibration with EPMC delivery, per-customer supply |
+
+All three share the same `resstock_kwh_scale_factor: 0.9568112362177266`.
+
+### Scenario mapping (RIE 1-8 and 1-9)
+
+| Scenario | Before                             | After                                | What changes                                          |
+| -------- | ---------------------------------- | ------------------------------------ | ----------------------------------------------------- |
+| RIE 1-8  | Run 1+2 (upgrade 0, default rates) | Run 3+4 (upgrade 2, default rates)   | Only the building upgrades to HP; rates stay the same |
+| RIE 1-9  | Run 1+2 (upgrade 0, default rates) | Run 19+20 (upgrade 2, HP flat rates) | Building upgrades AND gets the proposed HP rate       |
+
+## CAIRO processing pipeline
+
+### Step 1: Load hourly data
+
+`_return_loads_combined()` in `utils/mid/patches.py` reads the hourly parquet files
+and aligns them from 2018 to the target year (2025).
+
+### Step 2: Day-of-week timeshift
+
+**This is a non-obvious transformation.** CAIRO uses `np.roll` to shift hourly loads
+so that day-of-week patterns align with the target year:
+
+```python
+source_year = 2018  # Jan 1 = Monday (weekday 0)
+target_year = 2025  # Jan 1 = Wednesday (weekday 2)
+offset_days = (2 - 0) % 7 = 2
+offset_hours = 48
+
+elec_total = np.roll(elec_total.reshape(n_bldgs, 8760), -offset_hours, axis=1)
+```
+
+This shifts the first 48 hours of the year to the end. Effect:
+
+- January loses ~48 hours of winter load to December.
+- December gains those hours.
+
+For building 184434, this moves **127 kWh** from January to December. Monthly kWh
+totals differ from the raw ResStock monthly aggregates, but the **annual total is
+unchanged** (16,112.655 kWh).
+
+**Implication for hand-calculations:** You cannot reproduce CAIRO's monthly bills
+from the monthly load curve parquet files. You must either (a) use the hourly files
+with the 48-hour roll, or (b) accept that only the annual total matches.
+
+### Step 3: kWh scaling
+
+CAIRO multiplies all hourly loads by `kwh_scale_factor = 0.9568` (line 645 of
+`run_scenario.py`):
+
+```python
+raw_load_elec = raw_load_elec * settings.kwh_scale_factor
+```
+
+The scale factor is derived from:
+
+```
+kwh_scale_factor = test_year_residential_kwh / (resstock_total_kwh × customer_scale_factor)
+                 = 2,821,237,490 / (3,388,382,407 × 0.8702)
+                 = 0.9568
+```
+
+Building 184434 scaled annual kWh: 16,112.655 × 0.9568 = **15,416.8 kWh**.
+
+### Step 4: Customer weight scaling
+
+CAIRO also applies `customer_count_override` from the rev_req, which scales building
+weights:
+
+- Utility assignment weight: 252.30
+- CAIRO weight: 219.55 (= 252.30 × customer_scale_factor 0.8702)
+
+### Step 5: Billing
+
+For flat tariffs, CAIRO computes: `bill = Σ(hourly_kwh × rate) + fixed × 12`.
+
+Since the rate is constant across all hours, this simplifies to:
+`bill = annual_scaled_kwh × rate + fixed × 12`.
+
+| Run           | Bill          | Formula                         |
+| ------------- | ------------- | ------------------------------- |
+| 19 (delivery) | **$1,391.08** | 15,416.8 × 0.08249 + 10.01 × 12 |
+| 20 (supply)   | **$3,685.12** | 15,416.8 × 0.23129 + 10.01 × 12 |
+
+Hand-computed values match to within **$0.81/yr** (floating-point accumulation
+across 8760 hourly multiplications).
+
+## build_master_bills.py decomposition
+
+`build_master_bills.py` combines run 19 (delivery) and run 20 (delivery+supply)
+into the master bill components. The key logic:
+
+```python
+elec_fixed_charge  = rie_flat.json fixed × 12        # NOT the calibrated tariff's fixed
+elec_delivery_bill = bill_delivery − elec_fixed_charge
+elec_supply_bill   = bill_supply − bill_delivery
+elec_total_bill    = bill_supply
+```
+
+### Fixed charge overwrite
+
+The calibrated tariffs use **$10.01/mo** as `fixedchargefirstmeter`, but
+`build_master_bills.py` reads `rie_flat.json` which specifies **$11.47/mo**.
+
+This shifts **$17.52/yr** (= ($11.47 − $10.01) × 12) from `elec_delivery_bill`
+into `elec_fixed_charge`. The total bill is unchanged.
+
+`rie_flat.json` is not referenced in `scenarios_rie.yaml` — it is hardcoded in
+`build_master_bills.py` via `_read_fixed_charge()` which constructs the path
+`{utility}_flat.json`.
+
+### Result for building 184434 (run 19+20)
+
+| Component            | Value     | How computed                      |
+| -------------------- | --------- | --------------------------------- |
+| `elec_fixed_charge`  | $137.64   | 11.47 × 12 (from `rie_flat.json`) |
+| `elec_delivery_bill` | $1,253.44 | $1,391.08 − $137.64               |
+| `elec_supply_bill`   | $2,294.04 | $3,685.12 − $1,391.08             |
+| `elec_total_bill`    | $3,685.12 | = run 20 `bill_level`             |
+
+Check: $137.64 + $1,253.44 + $2,294.04 = $3,685.12 ✓
+
+### Effective rates
+
+Because the fixed charges cancel in the supply subtraction:
+
+- **Effective delivery volumetric**: `elec_delivery_bill / scaled_kwh` ≠ tariff rate
+  (because the rie_flat.json overwrite shifts $17.52 out of the delivery bill).
+- **Effective supply-only volumetric**: `elec_supply_bill / scaled_kwh` = supply_rate − delivery_rate
+  = 0.23129 − 0.08249 = **0.14880 $/kWh**. This is the incremental supply cost, not
+  the full supply tariff rate.
+
+## Supply rate: per-customer allocation
+
+The HP supply tariff (`rie_hp_flat_supply_calibrated.json`) uses a **bundled**
+delivery+supply rate of 0.23129 $/kWh. This is lower than the default seasonal
+supply rates (winter: 0.31377, summer: 0.24782, fall: 0.29493) because:
+
+1. It was calibrated using `rie_hp_vs_nonhp_rate_case_test_year.yaml`, which
+   allocates supply revenue with **per-customer** allocation (not passthrough).
+2. Per-customer allocation divides total supply revenue equally across all
+   customers. HP customers are ~2.5% of the base but consume proportionally
+   more kWh, so their per-kWh supply rate is lower.
+3. The bundled rate (0.23129) includes both delivery (0.08249) and supply
+   (0.14880 effective), so supply-only = 0.23129 − 0.08249 = 0.14880.
+
+## PV buildings and net metering
+
+14 of 1,910 RIE buildings (0.7%) have rooftop PV. Of these, **6 are gas-heated**
+and appear in the RIE 1-8/1-9 workbooks (0.57% of the 1,049 gas-heated buildings).
+
+| bldg_id | Total kWh | PV kWh  | Net kWh | Import-only kWh | PV coverage |
+| ------- | --------- | ------- | ------- | --------------- | ----------- |
+| 85645   | 10,574    | −8,360  | 2,214   | ~7,800*         | 79%         |
+| 121546  | 13,417    | −11,359 | 2,058   | ~8,200*         | 85%         |
+| 143685  | 12,828    | −11,648 | 1,180   | ~7,400*         | 91%         |
+| 222179  | 12,443    | −10,064 | 2,379   | ~7,500*         | 81%         |
+| 342077  | 15,014    | −6,296  | 8,718   | ~12,000*        | 42%         |
+| 516557  | 10,749    | −9,221  | 1,529   | ~7,700*         | 86%         |
+
+*Import-only kWh estimated from hourly data (hours where net ≥ 0).
+
+### How CAIRO bills PV buildings
+
+CAIRO computes `electricity_net = total − |pv|` per hour. Hours where `net < 0`
+(PV generation exceeds consumption) are **export hours**.
+
+Empirically (verified for building 8584, non-gas-heated PV):
+
+- `import_only_kwh × rate + fixed × 12 = $3,319.02`
+- Actual `elec_total_bill = $3,318.30`
+- Match within $0.72 (timeshift tolerance) ✓
+
+- `net_annual_kwh × rate + fixed × 12 = $2,706.54` ← does NOT match
+
+**Conclusion: export hours receive no credit (sell_rate ≈ 0).** The billed kWh
+equals the sum of only the hours where net consumption ≥ 0, ignoring export hours
+entirely.
+
+This is set in `run_scenario.py` where `solar_pv_compensation=None` is passed
+to `bs.simulate()` — the scenario's `solar_pv_compensation: net_metering` setting
+only determines the `sell_rate` passed separately, but the effective rate appears
+to be zero.
+
+### Implication for the workbook
+
+The back-derived `annual_kwh` (from delivery bills) correctly captures the
+import-only kWh because it is derived FROM the bill. The formula
+`(bill_delivery − annual_fixed) / vol_rate` produces the same kWh that CAIRO
+billed, regardless of PV.
+
+However, these kWh will NOT match the ResStock raw or net annual consumption
+for PV buildings. The workbook should note: "For 6 PV buildings (0.57% of
+gas-heated sample), `annual_kwh` reflects grid-consumed electricity only,
+excluding hours when rooftop solar exceeds consumption."
+
+## Key gotchas
+
+1. **Monthly bills don't match simple kWh × rate + fixed**, because of the 48-hour
+   day-of-week timeshift. Only annual totals can be verified with simple arithmetic.
+
+2. **`rie_flat.json` is the source of truth for `elec_fixed_charge`**, not the
+   calibrated tariff JSONs. The $11.47/mo includes customer charge ($6.00) + RE
+   Growth ($3.22) + other fixed charges, while the calibrated tariff's $10.01 is
+   CAIRO's internal representation.
+
+3. **The "supply" tariff in CAIRO is actually delivery+supply bundled.** The supply
+   component is extracted by subtraction: `bill_supply − bill_delivery`.
+
+4. **`kwh_scale_factor` is applied uniformly** to all hourly loads. It is NOT a
+   per-month calibration. Monthly deviations from `raw_monthly × kwh_sf` are
+   entirely due to the day-of-week timeshift.
+
+5. **The weight in CAIRO outputs differs from utility_assignment** because CAIRO
+   applies `customer_scale_factor` (0.8702) to the weights.
+
+6. **PV buildings are billed on import-only kWh** (hours where net ≥ 0). Export
+   hours receive no credit. Back-derived kWh correctly captures this, but won't
+   match ResStock raw totals for the 14 PV buildings (6 gas-heated).

--- a/reports/ri_hp_rates/testimony_response/context/workbook_reproducibility_plan.md
+++ b/reports/ri_hp_rates/testimony_response/context/workbook_reproducibility_plan.md
@@ -5,29 +5,15 @@
 Revise the RIE 1-8 and RIE 1-9 workbooks so that:
 
 1. A reviewer can **recreate every number** from documented inputs (tariff JSONs,
-   rev_req YAMLs, ResStock kWh, CAIRO bills).
+   exported billing kWh, CAIRO bills).
 2. The workbook values **match the expert testimony** (`expert_testimony.qmd`),
    specifically the inline computed values from `report_variables.pkl` and the
    figures from `analysis.qmd`.
 
-## Current state
+## Status: implemented
 
-The workbook already includes:
-
-- **per_building tab**: bldg_id, weight, annual_kwh_before, annual_kwh_after,
-  before/after bills (elec, gas, oil, propane with LMI adjustment), delta, save flag.
-- **result tab**: headline percentage (weighted share that saves/loses), computed
-  with live Excel formulas from per_building data.
-- **assumptions tab**: tariff tables (default before, HP after for 1-9), data
-  source S3 paths, column descriptions.
-
-### Gaps
-
-| Gap                                  | Impact                                                                                                                                                                                           |
-| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **kWh derivation is indirect**       | `annual_kwh` is back-derived from delivery bill via `(bill_delivery − annual_fixed_per_customer) / vol_rate`. This is opaque and doesn't surface the actual ResStock kWh or the scaling factors. |
-| **Tariff rates not linked to bills** | The assumptions tab lists tariff rates, but there's no formula connecting rates × kWh to the bill components.                                                                                    |
-| **Testimony figures not traceable**  | The testimony cites percentages (79% lose, 87% save) that come from `report_variables.pkl`. The workbook computes these independently but doesn't show they match.                               |
+All phases below have been implemented. The workbook script
+(`build_RIE_1_8_1_9_workbook.py`) has been updated.
 
 ## Approach: use total bills, not decomposed bills
 
@@ -41,101 +27,120 @@ Instead, the workbook presents:
 
 - **Total electric bill** from CAIRO (exact, unambiguous)
 - **Tariff rates** from the calibrated tariffs (matching the testimony)
-- **Fixed charge** of $10.01/mo ($120.12/yr) — the sum of the three per-customer
-  line items: $6.00 customer charge + $3.22 RE Growth + $0.79 LIHEAP Enhancement
-- **Verification**: `annual_kwh × vol_rate + $10.01 × 12 ≈ elec_total_bill`
-  (within ~$1 from CAIRO's hourly billing mechanics)
+- **Fixed charge** of $10.01/mo ($120.12/yr) — used consistently across all
+  workbooks (RIE 1-8, 1-9, and 1-11). This is the sum of the three per-customer
+  line items: $6.00 customer charge + $3.22 RE Growth + $0.79 LIHEAP Enhancement.
+  It matches `fixedchargefirstmeter = 10.01` in all calibrated tariff JSONs and
+  what the testimony cites.
+- **Billing kWh** exported directly from CAIRO's billing pipeline
+  (`billing_kwh_annual.parquet`), not back-derived from bills.
 
-This is consistent with the testimony, the calibrated tariffs, and what CAIRO
-actually billed against (`fixedchargefirstmeter = 10.01` in all calibrated JSONs).
+## Key decisions
 
-## Plan
+### Consistent fixed charge: $10.01/mo
 
-### Phase 1: Link tariff rates to bill verification formulas
+All workbooks use $10.01/mo ($120.12/yr). This is:
 
-In the assumptions tab, add a **"How to verify"** section:
+- The sum of the three per-customer line items on the bill ($6.00 customer charge
+  - $3.22 RE Growth + $0.79 LIHEAP Enhancement)
+- What the calibrated tariff JSONs use (`fixedchargefirstmeter = 10.01`)
+- What the testimony cites as the fixed charges
+- What CAIRO actually bills against hourly
+
+Other fixed charge values exist in different contexts but are NOT used in the
+workbooks:
+
+- $11.47/mo — `rie_flat.json` (used only by `build_master_bills.py` to
+  decompose the bill into delivery/supply components; not the actual billing
+  fixed charge)
+- $117.54/yr — revenue-equation residual from the old kWh back-derivation
+  (now removed)
+- $137.64/yr ($11.47 × 12) — what `build_master_bills.py` reports as
+  `elec_fixed_charge` (a different decomposition)
+
+### kWh source: exported from CAIRO billing pipeline
+
+kWh values are loaded from `billing_kwh_annual.parquet`, exported directly from
+CAIRO's billing pipeline during runs. These are the exact grid-consumed kWh that
+CAIRO uses for billing, after:
+
+- PV clipping (`grid_cons = max(electricity_net, 0)`)
+- `kwh_scale_factor` application (0.9568)
+- 48-hour day-of-week timeshift (aligning 2018 weather year to 2025)
+
+Each building gets exactly two kWh values: upgrade 0 (before HP) and upgrade 2
+(after HP). These are the same regardless of which tariff is applied.
+
+Source files:
+
+- Upgrade 0: `s3://data.sb/switchbox/cairo/outputs/hp_rates/ri/rie/ri_20260504_kwh_export_v2/20260505_011359_ri_rie_run1_up00_precalc__default/billing_kwh_annual.parquet`
+- Upgrade 2: `s3://data.sb/switchbox/cairo/outputs/hp_rates/ri/rie/ri_20260504_kwh_export_v2/20260505_011437_ri_rie_run3_up02_default__default/billing_kwh_annual.parquet`
+
+### Bill-verification formula: RIE 1-9 only
+
+RIE 1-9 uses the HP flat supply tariff (`rie_hp_flat_supply_calibrated.json`),
+which has a single flat rate of 23.129 ¢/kWh (delivery + supply bundled). The
+verification formula is:
 
 ```
-For building i with annual_kwh_after = K:
-
-  RIE 1-8 (default rates, after HP):
-    elec_total_bill ≈ K × weighted_avg_supply_rate + $10.01 × 12
-    The default supply tariff is seasonal (winter/summer/shoulder),
-    so the annual bill depends on each building's monthly consumption
-    profile. The annual total matches CAIRO output within ~$1.
-
-  RIE 1-9 (HP flat rates, after HP):
-    elec_total_bill ≈ K × 0.23129 + $10.01 × 12
-    The HP flat supply tariff is a single flat rate (delivery+supply
-    bundled). This formula reproduces CAIRO's total bill within ~$1.
-
-  Fixed charge ($10.01/mo):
-    $6.00/mo customer charge + $3.22/mo RE Growth + $0.79/mo LIHEAP
-    Enhancement. These are unchanged by the proposal.
-
-  The ~$1 tolerance arises from CAIRO's hourly billing mechanics
-  (48-hour day-of-week timeshift aligning 2018 weather year to 2025).
+elec_bill_formula = annual_kwh_after × 0.23129 + 10.01 × 12
 ```
 
-### Phase 2: Surface the kWh derivation
+This reproduces CAIRO's total bill within ~$1. The residual column
+(`elec_bill_residual = elec_bill_after - elec_bill_formula`) is included in the
+per_building sheet.
 
-The current kWh back-derivation (`(bill_delivery − fixed) / vol_rate`) is opaque.
-Document the derivation clearly:
+### Why no bill-verification formula for RIE 1-8
 
-1. kWh are derived from the status-quo delivery run (run 1+2), where the tariff
-   is a single flat rate: `annual_kwh = (annual_bill_delivery − $117.54) / 0.14078`.
-   The $117.54 is the revenue-equation residual (see `cairo_bill_decomposition.md`).
-2. This produces the same kWh for both RIE 1-8 and RIE 1-9 (before = upgrade 0,
-   after = upgrade 2).
-3. For 6 PV buildings, `annual_kwh` reflects grid-consumed electricity only
-   (import-only kWh), because CAIRO does not credit export hours.
+The default supply tariff (`rie_default_supply_calibrated.json`) uses three
+seasonal rates:
 
-Add a note in the assumptions tab explaining this derivation and citing the
-`kwh_scale_factor = 0.9568` from `rie_rate_case_test_year.yaml`.
+- Winter (Jan, Feb, Mar, Nov, Dec): 31.38 ¢/kWh
+- Summer (Jun, Jul, Aug, Sep): 24.78 ¢/kWh
+- Shoulder (Apr, May, Oct): 29.49 ¢/kWh
 
-### Phase 3: Cross-reference with testimony
+These rates bundle delivery + supply. Because each building has a different
+monthly consumption profile, a single `annual_kwh × rate` formula cannot
+reproduce the bill — it would require 12 monthly kWh values and per-month rate
+assignments. CAIRO computes bills hourly (8,760 hours), applying the correct
+seasonal rate to each hour's consumption, then sums to the annual total.
 
-Add a **testimony_match** section in the assumptions tab that maps workbook
-outputs to specific testimony claims:
+The `elec_total_bill` column is the exact annual bill from CAIRO. To verify it
+independently, one would need the building's hourly load profile (available in
+`billing_kwh_8760.parquet`) and the seasonal rate schedule above.
 
-| Testimony claim                                 | Testimony source                                         | Workbook cell            | Match?     |
-| ----------------------------------------------- | -------------------------------------------------------- | ------------------------ | ---------- |
-| "79% of gas-heated households would lose money" | Section V, inline `pct(v.pct_natgas_lose_default_lmi40)` | result!B2                | Must match |
-| "87% of gas-heated households would save money" | Section V, inline `pct(v.pct_natgas_save_hprate_lmi40)`  | result!B2                | Must match |
-| Delivery rate 14.08 ¢/kWh                       | Section V, rate comparison tables                        | assumptions tariff table | Must match |
-| HP delivery rate 8.25 ¢/kWh                     | Section V, `cents(c.hp_pct_reduction)`                   | assumptions tariff table | Must match |
-| Fixed charge $10.01/mo                          | Section V, `fixed_charges_description`                   | assumptions tariff table | Must match |
-| LMI discount at 32% enrollment                  | Section VI                                               | assumptions tab          | Must match |
+## What each workbook tab contains
 
-### Phase 4: Documentation
+### assumptions tab
 
-1. Update the assumptions tab "How bills are computed" section:
-   - Bills come from CAIRO's hourly simulation (ResStock loads × tariff rates).
-   - The fixed charge is $10.01/mo, matching the calibrated tariff JSONs and testimony.
-   - CAIRO applies a `kwh_scale_factor` of 0.9568 and a 48-hour day-of-week
-     timeshift (aligning 2018 weather loads to 2025 calendar), which produces
-     small (~$1) differences from `kWh × annual_rate + fixed × 12`.
-2. Reference `cairo_bill_decomposition.md` for full technical details.
+- Discovery request text
+- LMI discount tier (32% enrollment)
+- Bill columns used and filtering criteria
+- **Tariff tables**: Default tariffs (before) and HP subclass tariffs (after,
+  1-9 only), replicating `tbl-rie-energy-tariffs` from the testimony. Includes
+  electric delivery, supply (seasonal and flat), gas, oil, and propane rates.
+- **How bills are computed**: Fixed charge ($10.01/mo), kWh source (exported
+  from CAIRO), electric bill source (CAIRO hourly simulation).
+- **Why no formula (1-8)** or **Bill-verification formula (1-9)**: Explains
+  the seasonal rate limitation for 1-8, or provides the verification formula
+  for 1-9.
+- **Data sources**: S3 paths for master bills and billing kWh parquets.
+- **Column descriptions**: All per_building columns documented.
 
-## Implementation order
+### per_building tab
 
-1. **Phase 1 first** — linking rates to verification formulas is the most impactful
-   for reproducibility and doesn't require loading new data.
-2. **Phase 3 next** — cross-reference ensures testimony match.
-3. **Phase 2** — kWh derivation documentation (the current back-derivation works;
-   this phase clarifies it).
-4. **Phase 4 throughout** — documentation updates happen alongside each phase.
+- bldg_id, weight
+- annual_kwh_before (upgrade 0), annual_kwh_after (upgrade 2)
+- Before/after bills: elec, gas, oil, propane (undiscounted and LMI-adjusted)
+- LMI discount amounts, total energy bills, delta, saves flag, weighted saves
+- **RIE 1-9 only**: elec_bill_formula and elec_bill_residual columns
 
-## Files involved
+### result tab
 
-| File                                                     | Role                              |
-| -------------------------------------------------------- | --------------------------------- |
-| `testimony_response/build_RIE_1_8_1_9_workbook.py`       | Primary script to modify          |
-| `testimony_response/verify_RIE_1_8_1_9_workbook.py`      | Verification script               |
-| `testimony_response/context/cairo_bill_decomposition.md` | Reference for bill mechanics      |
-| `cache/report_variables.pkl`                             | Source of testimony inline values |
-| `notebooks/analysis.qmd`                                 | Source of testimony figures       |
-| `expert_testimony.qmd`                                   | The testimony document itself     |
+- Total gas-heated customers (weighted)
+- Customers that save (weighted)
+- Percentage that save / lose
+- Headline figure
 
 ## Key tariff files (rate-design-platform)
 
@@ -150,10 +155,21 @@ All calibrated tariffs use `fixedchargefirstmeter = 10.01` ($6.00 + $3.22 + $0.7
 
 ## CAIRO batch and runs
 
-Batch: `ri_20260331_r1-20_rate_case_test_year`
+Bills batch: `ri_20260331_r1-20_rate_case_test_year`
+kWh batch: `ri_20260504_kwh_export_v2`
 
 | Master bill path                    | Runs                        | Description                           |
 | ----------------------------------- | --------------------------- | ------------------------------------- |
 | `run_1+2/comb_bills_year_target/`   | 1 (delivery) + 2 (supply)   | Before: upgrade 0, default rates      |
 | `run_3+4/comb_bills_year_target/`   | 3 (delivery) + 4 (supply)   | After (1-8): upgrade 2, default rates |
 | `run_19+20/comb_bills_year_target/` | 19 (delivery) + 20 (supply) | After (1-9): upgrade 2, HP flat rates |
+
+## Files involved
+
+| File                                                     | Role                              |
+| -------------------------------------------------------- | --------------------------------- |
+| `testimony_response/build_RIE_1_8_1_9_workbook.py`       | Primary script (updated)          |
+| `testimony_response/context/cairo_bill_decomposition.md` | Reference for bill mechanics      |
+| `cache/report_variables.pkl`                             | Source of testimony inline values |
+| `notebooks/analysis.qmd`                                 | Source of testimony figures       |
+| `expert_testimony.qmd`                                   | The testimony document itself     |

--- a/reports/ri_hp_rates/testimony_response/context/workbook_reproducibility_plan.md
+++ b/reports/ri_hp_rates/testimony_response/context/workbook_reproducibility_plan.md
@@ -1,0 +1,159 @@
+# Plan: reproducible RIE 1-8/1-9 workbooks
+
+## Goal
+
+Revise the RIE 1-8 and RIE 1-9 workbooks so that:
+
+1. A reviewer can **recreate every number** from documented inputs (tariff JSONs,
+   rev_req YAMLs, ResStock kWh, CAIRO bills).
+2. The workbook values **match the expert testimony** (`expert_testimony.qmd`),
+   specifically the inline computed values from `report_variables.pkl` and the
+   figures from `analysis.qmd`.
+
+## Current state
+
+The workbook already includes:
+
+- **per_building tab**: bldg_id, weight, annual_kwh_before, annual_kwh_after,
+  before/after bills (elec, gas, oil, propane with LMI adjustment), delta, save flag.
+- **result tab**: headline percentage (weighted share that saves/loses), computed
+  with live Excel formulas from per_building data.
+- **assumptions tab**: tariff tables (default before, HP after for 1-9), data
+  source S3 paths, column descriptions.
+
+### Gaps
+
+| Gap                                  | Impact                                                                                                                                                                                           |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **kWh derivation is indirect**       | `annual_kwh` is back-derived from delivery bill via `(bill_delivery − annual_fixed_per_customer) / vol_rate`. This is opaque and doesn't surface the actual ResStock kWh or the scaling factors. |
+| **Tariff rates not linked to bills** | The assumptions tab lists tariff rates, but there's no formula connecting rates × kWh to the bill components.                                                                                    |
+| **Testimony figures not traceable**  | The testimony cites percentages (79% lose, 87% save) that come from `report_variables.pkl`. The workbook computes these independently but doesn't show they match.                               |
+
+## Approach: use total bills, not decomposed bills
+
+The workbook uses `elec_total_bill` from CAIRO directly — the unambiguous total
+electric bill. It does **not** decompose into `elec_fixed_charge` /
+`elec_delivery_bill` / `elec_supply_bill`, because that decomposition uses
+`rie_flat.json` ($11.47/mo) via `build_master_bills.py`, which differs from the
+$10.01/mo fixed charge in the calibrated tariffs and the testimony.
+
+Instead, the workbook presents:
+
+- **Total electric bill** from CAIRO (exact, unambiguous)
+- **Tariff rates** from the calibrated tariffs (matching the testimony)
+- **Fixed charge** of $10.01/mo ($120.12/yr) — the sum of the three per-customer
+  line items: $6.00 customer charge + $3.22 RE Growth + $0.79 LIHEAP Enhancement
+- **Verification**: `annual_kwh × vol_rate + $10.01 × 12 ≈ elec_total_bill`
+  (within ~$1 from CAIRO's hourly billing mechanics)
+
+This is consistent with the testimony, the calibrated tariffs, and what CAIRO
+actually billed against (`fixedchargefirstmeter = 10.01` in all calibrated JSONs).
+
+## Plan
+
+### Phase 1: Link tariff rates to bill verification formulas
+
+In the assumptions tab, add a **"How to verify"** section:
+
+```
+For building i with annual_kwh_after = K:
+
+  RIE 1-8 (default rates, after HP):
+    elec_total_bill ≈ K × weighted_avg_supply_rate + $10.01 × 12
+    The default supply tariff is seasonal (winter/summer/shoulder),
+    so the annual bill depends on each building's monthly consumption
+    profile. The annual total matches CAIRO output within ~$1.
+
+  RIE 1-9 (HP flat rates, after HP):
+    elec_total_bill ≈ K × 0.23129 + $10.01 × 12
+    The HP flat supply tariff is a single flat rate (delivery+supply
+    bundled). This formula reproduces CAIRO's total bill within ~$1.
+
+  Fixed charge ($10.01/mo):
+    $6.00/mo customer charge + $3.22/mo RE Growth + $0.79/mo LIHEAP
+    Enhancement. These are unchanged by the proposal.
+
+  The ~$1 tolerance arises from CAIRO's hourly billing mechanics
+  (48-hour day-of-week timeshift aligning 2018 weather year to 2025).
+```
+
+### Phase 2: Surface the kWh derivation
+
+The current kWh back-derivation (`(bill_delivery − fixed) / vol_rate`) is opaque.
+Document the derivation clearly:
+
+1. kWh are derived from the status-quo delivery run (run 1+2), where the tariff
+   is a single flat rate: `annual_kwh = (annual_bill_delivery − $117.54) / 0.14078`.
+   The $117.54 is the revenue-equation residual (see `cairo_bill_decomposition.md`).
+2. This produces the same kWh for both RIE 1-8 and RIE 1-9 (before = upgrade 0,
+   after = upgrade 2).
+3. For 6 PV buildings, `annual_kwh` reflects grid-consumed electricity only
+   (import-only kWh), because CAIRO does not credit export hours.
+
+Add a note in the assumptions tab explaining this derivation and citing the
+`kwh_scale_factor = 0.9568` from `rie_rate_case_test_year.yaml`.
+
+### Phase 3: Cross-reference with testimony
+
+Add a **testimony_match** section in the assumptions tab that maps workbook
+outputs to specific testimony claims:
+
+| Testimony claim                                 | Testimony source                                         | Workbook cell            | Match?     |
+| ----------------------------------------------- | -------------------------------------------------------- | ------------------------ | ---------- |
+| "79% of gas-heated households would lose money" | Section V, inline `pct(v.pct_natgas_lose_default_lmi40)` | result!B2                | Must match |
+| "87% of gas-heated households would save money" | Section V, inline `pct(v.pct_natgas_save_hprate_lmi40)`  | result!B2                | Must match |
+| Delivery rate 14.08 ¢/kWh                       | Section V, rate comparison tables                        | assumptions tariff table | Must match |
+| HP delivery rate 8.25 ¢/kWh                     | Section V, `cents(c.hp_pct_reduction)`                   | assumptions tariff table | Must match |
+| Fixed charge $10.01/mo                          | Section V, `fixed_charges_description`                   | assumptions tariff table | Must match |
+| LMI discount at 32% enrollment                  | Section VI                                               | assumptions tab          | Must match |
+
+### Phase 4: Documentation
+
+1. Update the assumptions tab "How bills are computed" section:
+   - Bills come from CAIRO's hourly simulation (ResStock loads × tariff rates).
+   - The fixed charge is $10.01/mo, matching the calibrated tariff JSONs and testimony.
+   - CAIRO applies a `kwh_scale_factor` of 0.9568 and a 48-hour day-of-week
+     timeshift (aligning 2018 weather loads to 2025 calendar), which produces
+     small (~$1) differences from `kWh × annual_rate + fixed × 12`.
+2. Reference `cairo_bill_decomposition.md` for full technical details.
+
+## Implementation order
+
+1. **Phase 1 first** — linking rates to verification formulas is the most impactful
+   for reproducibility and doesn't require loading new data.
+2. **Phase 3 next** — cross-reference ensures testimony match.
+3. **Phase 2** — kWh derivation documentation (the current back-derivation works;
+   this phase clarifies it).
+4. **Phase 4 throughout** — documentation updates happen alongside each phase.
+
+## Files involved
+
+| File                                                     | Role                              |
+| -------------------------------------------------------- | --------------------------------- |
+| `testimony_response/build_RIE_1_8_1_9_workbook.py`       | Primary script to modify          |
+| `testimony_response/verify_RIE_1_8_1_9_workbook.py`      | Verification script               |
+| `testimony_response/context/cairo_bill_decomposition.md` | Reference for bill mechanics      |
+| `cache/report_variables.pkl`                             | Source of testimony inline values |
+| `notebooks/analysis.qmd`                                 | Source of testimony figures       |
+| `expert_testimony.qmd`                                   | The testimony document itself     |
+
+## Key tariff files (rate-design-platform)
+
+All calibrated tariffs use `fixedchargefirstmeter = 10.01` ($6.00 + $3.22 + $0.79).
+
+| File                                 | Rate                                                       | Used in runs |
+| ------------------------------------ | ---------------------------------------------------------- | ------------ |
+| `rie_default_calibrated.json`        | 14.078 ¢/kWh flat delivery                                 | 1, 3         |
+| `rie_default_supply_calibrated.json` | Seasonal delivery+supply bundled (31.38/24.78/29.49 ¢/kWh) | 2, 4         |
+| `rie_hp_flat_calibrated.json`        | 8.249 ¢/kWh flat HP delivery                               | 19           |
+| `rie_hp_flat_supply_calibrated.json` | 23.129 ¢/kWh flat HP delivery+supply bundled               | 20           |
+
+## CAIRO batch and runs
+
+Batch: `ri_20260331_r1-20_rate_case_test_year`
+
+| Master bill path                    | Runs                        | Description                           |
+| ----------------------------------- | --------------------------- | ------------------------------------- |
+| `run_1+2/comb_bills_year_target/`   | 1 (delivery) + 2 (supply)   | Before: upgrade 0, default rates      |
+| `run_3+4/comb_bills_year_target/`   | 3 (delivery) + 4 (supply)   | After (1-8): upgrade 2, default rates |
+| `run_19+20/comb_bills_year_target/` | 19 (delivery) + 20 (supply) | After (1-9): upgrade 2, HP flat rates |

--- a/reports/ri_hp_rates/testimony_response/verify_RIE_1_8_1_9_workbook.py
+++ b/reports/ri_hp_rates/testimony_response/verify_RIE_1_8_1_9_workbook.py
@@ -1,0 +1,119 @@
+"""Verify the RIE 1-8 and RIE 1-9 workbooks reproduce the testimony numbers.
+
+Two checks per workbook:
+
+1. **Structural** — open the xlsx and confirm expected sheets, formula columns.
+2. **Numerical** — confirm the save/lose percentages match report_variables.pkl.
+"""
+
+from __future__ import annotations
+
+import pickle
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from openpyxl import load_workbook
+
+REPORT_DIR = Path("/ebs/home/alex_switch_box/reports2/reports/ri_hp_rates")
+CACHE_DIR = REPORT_DIR / "cache"
+
+
+def _load_report_vars() -> SimpleNamespace:
+    pkl = CACHE_DIR / "report_variables.pkl"
+    assert pkl.exists(), f"Missing {pkl}. Render analysis.qmd first."
+    return SimpleNamespace(**pickle.loads(pkl.read_bytes()))
+
+
+def _structural_check(xlsx_path: Path) -> None:
+    print(f"=== Structural check: {xlsx_path.name} ===")
+    wb = load_workbook(str(xlsx_path), data_only=False)
+
+    expected_sheets = ["assumptions", "per_building", "result"]
+    missing = [s for s in expected_sheets if s not in wb.sheetnames]
+    assert not missing, f"missing sheets: {missing}"
+    print(f"  sheets: {wb.sheetnames}")
+
+    pb = wb["per_building"]
+    headers = [pb.cell(row=1, column=c).value for c in range(1, 22)]
+    assert headers[0] == "bldg_id", f"unexpected first header: {headers[0]}"
+    assert headers[18] == "delta", f"expected 'delta' in col S, got: {headers[18]}"
+    assert headers[19] == "saves", f"expected 'saves' in col T, got: {headers[19]}"
+    assert headers[20] == "w_saves", f"expected 'w_saves' in col U, got: {headers[20]}"
+    print("  per_building headers: OK")
+
+    cell_s2 = pb["S2"].value
+    assert isinstance(cell_s2, str) and cell_s2.startswith("="), f"S2 should be a formula, got: {cell_s2}"
+    print("  formulas in per_building: OK")
+
+    result_ws = wb["result"]
+    b6 = result_ws["B6"].value
+    assert isinstance(b6, str) and "B5" in b6, f"B6 should reference B5, got: {b6}"
+    print("  result sheet formulas: OK")
+    print()
+
+
+def _numerical_check(xlsx_path: Path, expected_pct_save: float, label: str) -> None:
+    """Check pct_save from raw data columns (formulas aren't evaluated in openpyxl)."""
+    print(f"=== Numerical check: {label} ({xlsx_path.name}) ===")
+    wb = load_workbook(str(xlsx_path), data_only=False)
+    pb = wb["per_building"]
+
+    # LMI bill columns (D=elec_lmi_before, F=gas_lmi_before, G=oil_before,
+    # H=propane_before, J=elec_lmi_after, L=gas_lmi_after, M=oil_after,
+    # N=propane_after); weight = col B (index 1)
+    total_w = 0.0
+    save_w = 0.0
+    for row in pb.iter_rows(min_row=2, values_only=True):
+        if row[0] is None:
+            break
+        weight = float(row[1])
+        total_w += weight
+        # D(3) + F(5) + G(6) + H(7) = energy_bill_lmi_before
+        before = float(row[3]) + float(row[5]) + float(row[6]) + float(row[7])
+        # J(9) + L(11) + M(12) + N(13) = energy_bill_lmi_after
+        after = float(row[9]) + float(row[11]) + float(row[12]) + float(row[13])
+        if after - before < 0:
+            save_w += weight
+
+    actual_pct_save = save_w / total_w
+    diff = abs(actual_pct_save - expected_pct_save)
+    print(f"  expected pct_save: {expected_pct_save:.6f}")
+    print(f"  actual pct_save:   {actual_pct_save:.6f}")
+    print(f"  delta:             {diff:.6f}")
+    assert diff < 0.001, f"pct_save mismatch for {label}: {diff:.6f}"
+    print("  PASS")
+    print()
+
+
+def main() -> int:
+    v = _load_report_vars()
+
+    xlsx_1_8 = CACHE_DIR / "rie_1_8.xlsx"
+    xlsx_1_9 = CACHE_DIR / "rie_1_9.xlsx"
+
+    for p in (xlsx_1_8, xlsx_1_9):
+        if not p.exists():
+            print(f"ERROR: {p} not found. Run build_RIE_1_8_1_9_workbook.py first.")
+            return 1
+
+    _structural_check(xlsx_1_8)
+    _structural_check(xlsx_1_9)
+
+    _numerical_check(
+        xlsx_1_8,
+        expected_pct_save=v.pct_natgas_save_default_lmi40,
+        label="RIE 1-8 (default rates, 79% lose)",
+    )
+    _numerical_check(
+        xlsx_1_9,
+        expected_pct_save=v.pct_natgas_save_hprate_lmi40,
+        label="RIE 1-9 (HP rates, 87% save)",
+    )
+
+    print("All checks PASSED.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `build_RIE_1_8_1_9_workbook.py` — a workbook builder for the two headline bill-savings discovery requests (RIE 1-8: 79% lose money under default rates; RIE 1-9: 87% save under proposed rates).
- Each workbook has four sheets: `assumptions` (tariff tables, data sources, column descriptions), `monthly` (12 rows per building with consumption x rate = bill formulas), `annual` (SUM of monthly + LMI-adjusted bills + delta/saves), and `result` (headline percentage).
- Also includes updates to the marginal costs workbook (`build_marginal_costs_workbook.py`) adding delivery-only mode, and renames/refactors to existing workbook builders (`build_RIE_1_11_DIV_7_workbook.py`, `build_RIE_1_5_DIV_1_1_workbook.py`).
- Adds verification scripts and context docs for bill decomposition and workbook reproducibility.

## Reviewer focus

- The monthly→annual bill derivation logic in `build_RIE_1_8_1_9_workbook.py` — especially the LMI conditional (use master bills if discounted, formula sum if not).
- The `ty: ignore[invalid-return-type]` suppressions on `.collect()` calls — polars returns `DataFrame | InProcessQuery` in newer versions.

Closes #170

Made with [Cursor](https://cursor.com)