### PR TITLE
[md_hp_rates] Add BGE rate-case analysis and shared rate-case functions

### DIFF
--- a/lib/rates_analysis/rate_case_funcs.py
+++ b/lib/rates_analysis/rate_case_funcs.py
@@ -1,0 +1,368 @@
+"""Generalized rate-case analysis functions, shared across states/batches/scenarios.
+
+These functions read CAIRO's Prefect-produced master tables (see the
+rate-design-platform AGENTS.md "Master tables" section and
+https://github.com/switchbox-data/rate-design-platform/pull/503 for how they're
+built) and compute the statistics rate-case reports need: bill-change incidence,
+heat-pump delivery over/underpayment (BAT), representative-household bill
+decomposition, and tariff introspection.
+
+Every function is parameterized by ``state``, ``batch``, and ``scenario`` (never
+hardcoded to one state or run) so the same code works for today's ``default``
+schedule and for scenarios that don't exist yet (e.g. a future ``hp_flat_*``
+design) without changes.
+
+Terminology, following the new Prefect orchestration (no more numbered runs):
+
+- A **scenario** is a named tariff design (e.g. ``"default"``,
+  ``"hp_seasonal_percustomer_passthrough"``).
+- A **stage** is either ``"precalc"`` (ResStock upgrade 00, today's mixed
+  heating population, un-recalibrated tariff) or ``"calibrated"`` (ResStock
+  upgrade 02, buildings retrofitted to HP, tariff recalibrated to meet revenue
+  requirements).
+- A **segment** is ``"{scenario}_{stage}"`` — the directory name CAIRO's
+  post-processing writes master tables under.
+
+Critical fact from PR #503: cross-subsidy/BAT metrics are only reliable at the
+``precalc`` stage. Calibrated-stage BAT is inflated by a deliberately oversized
+revenue requirement — bills themselves are correct at that stage, but
+BAT/``residual_share`` is not. Every BAT-reading function here reads
+``{scenario}_precalc`` only.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    import polars as pl
+
+S3_BASE = "s3://data.sb/switchbox/cairo/outputs/hp_rates"
+MONTH_ORDER = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+# --- Loading -----------------------------------------------------------------
+
+
+def segment_name(scenario: str, stage: str) -> str:
+    """Return the ``{scenario}_{stage}`` segment name CAIRO writes master tables under."""
+    return f"{scenario}_{stage}"
+
+
+def master_table_uri(
+    state: str,
+    batch: str,
+    segment: str,
+    dataset: str,
+    *,
+    all_utilities: bool = True,
+    utility: str | None = None,
+) -> str:
+    """Return the S3 URI for a master-table dataset within a batch segment.
+
+    Only the ``all_utilities`` master tables (Hive-partitioned by
+    ``sb.electric_utility``, one row per building) are wired up here — they are
+    the primary data source per the rate-design-platform AGENTS.md. To scope to
+    one utility, filter the loaded frame by ``sb.electric_utility`` instead of
+    passing a per-utility path; pass ``utility`` only for documentation/clarity
+    at call sites, it doesn't change the URI.
+    """
+    if not all_utilities:
+        raise NotImplementedError(
+            "Per-utility raw run paths (with a cairo_ts prefix) aren't wired up here. "
+            "Use the all_utilities master tables and filter by `sb.electric_utility` instead."
+        )
+    del utility  # documentation-only; see docstring
+    return f"{S3_BASE}/{state.lower()}/all_utilities/{batch}/{segment}/{dataset}/"
+
+
+def load_master_bills(state: str, batch: str, segment: str) -> pl.LazyFrame:
+    """Load the ``comb_bills_year_target`` master table for one batch segment.
+
+    One row per building per month (Jan-Dec + Annual), incl. ``energy_total_bill``,
+    ``postprocess_group.heating_type_v2``, ``postprocess_group.has_hp``, ``weight``.
+    """
+    import polars as pl
+
+    return pl.scan_parquet(
+        master_table_uri(state, batch, segment, "comb_bills_year_target"),
+        hive_partitioning=True,
+    )
+
+
+def load_master_bat(state: str, batch: str, segment: str) -> pl.LazyFrame:
+    """Load the ``cross_subsidization_BAT_values`` master table for one batch segment.
+
+    One row per building (annual), incl. ``BAT_percustomer_delivery``,
+    ``annual_bill_delivery``, ``postprocess_group.has_hp``, ``weight``.
+
+    Warning: BAT values are only valid at the ``precalc`` stage (see module
+    docstring / PR #503). Calibrated-stage BAT is inflated by an oversized
+    revenue requirement; don't use ``*_calibrated`` segments for cross-subsidy
+    analysis, even though the bills in that segment are correct.
+    """
+    import polars as pl
+
+    if not segment.endswith("_precalc"):
+        warnings.warn(
+            f"Loading BAT from segment {segment!r}, which is not a `_precalc` segment. "
+            "Calibrated-stage BAT is inflated and unsuitable for cross-subsidy analysis (see PR #503).",
+            stacklevel=2,
+        )
+    return pl.scan_parquet(
+        master_table_uri(state, batch, segment, "cross_subsidization_BAT_values"),
+        hive_partitioning=True,
+    )
+
+
+# --- Weighted stats ------------------------------------------------------------
+
+
+def weighted_mean(df: pl.DataFrame, col: str, weight_col: str = "weight") -> float:
+    """Weighted arithmetic mean of *col*."""
+    numerator = float((df[col] * df[weight_col]).sum())
+    denominator = float(df[weight_col].sum())
+    return numerator / denominator
+
+
+def weighted_quantile(df: pl.DataFrame, col: str, q: float, weight_col: str = "weight") -> float:
+    """Weighted quantile of *col* via cumulative weight (e.g. ``q=0.5`` for the median)."""
+    sorted_df = df.sort(col)
+    total_weight = float(sorted_df[weight_col].sum())
+    cum = sorted_df[weight_col].cum_sum() / total_weight
+    return float(sorted_df.filter(cum >= q)[col][0])
+
+
+def weighted_pct(df: pl.DataFrame, predicate: pl.Expr | pl.Series, weight_col: str = "weight") -> float:
+    """Weighted share of rows in *df* matching *predicate* (a boolean Polars expression or mask)."""
+    total = float(df[weight_col].sum())
+    matching = float(df.filter(predicate)[weight_col].sum())
+    return matching / total
+
+
+# --- Bill-change diff ----------------------------------------------------------
+
+
+def bill_delta_between_segments(
+    state: str,
+    batch: str,
+    segment_before: str,
+    segment_after: str,
+    *,
+    bill_col: str = "energy_total_bill",
+    month: str = "Annual",
+) -> pl.DataFrame:
+    """Diff a per-building bill column between any two ``{scenario}_{stage}`` segments.
+
+    Both axes of comparison reduce to the same join on ``bldg_id``:
+
+    - Same scenario, different stage (e.g. ``"default_precalc"`` ->
+      ``"default_calibrated"``): before/after a heat-pump retrofit, holding the
+      tariff fixed.
+    - Same stage, different scenario (e.g. ``"default_precalc"`` ->
+      ``"hp_seasonal_percustomer_passthrough_precalc"``): same population,
+      comparing two tariffs.
+
+    Metadata columns (``heating_type_v2``, ``has_hp``) are carried from
+    *segment_before* — they are baseline-derived and identical across
+    segments/stages for the same population (see rate-design-platform PR #503's
+    ``master_metadata.py``).
+
+    Returns a DataFrame with ``bldg_id``, ``weight``, ``has_hp``,
+    ``heating_type_v2``, ``bill_before``, ``bill_after``, ``delta``.
+    """
+    import polars as pl
+
+    before = (
+        load_master_bills(state, batch, segment_before)
+        .filter(pl.col("month") == month)
+        .select(
+            "bldg_id",
+            "weight",
+            pl.col(bill_col).alias("bill_before"),
+            pl.col("postprocess_group.has_hp").alias("has_hp"),
+            pl.col("postprocess_group.heating_type_v2").alias("heating_type_v2"),
+        )
+    )
+    after = (
+        load_master_bills(state, batch, segment_after)
+        .filter(pl.col("month") == month)
+        .select("bldg_id", pl.col(bill_col).alias("bill_after"))
+    )
+    joined = before.join(after, on="bldg_id", how="inner").with_columns(
+        (pl.col("bill_after") - pl.col("bill_before")).alias("delta")
+    )
+    return cast("pl.DataFrame", joined.collect())
+
+
+def bill_change_incidence(delta_df: pl.DataFrame, weight_col: str = "weight") -> dict:
+    """Weighted incidence stats for a ``bill_delta_between_segments`` result.
+
+    Composes on top of any such result regardless of which axis (before/after
+    retrofit, or same population/different tariff) it came from.
+    """
+    total = delta_df[weight_col].sum()
+    return {
+        "pct_increase": weighted_pct(delta_df, delta_df["delta"] > 0, weight_col),
+        "pct_decrease": weighted_pct(delta_df, delta_df["delta"] < 0, weight_col),
+        "pct_unchanged": weighted_pct(delta_df, delta_df["delta"] == 0, weight_col),
+        "mean_delta": weighted_mean(delta_df, "delta", weight_col),
+        "median_delta": weighted_quantile(delta_df, "delta", 0.5, weight_col),
+        "n_weighted": float(total),
+    }
+
+
+# --- HP overpayment / BAT -------------------------------------------------------
+
+
+def hp_bat_summary(
+    state: str,
+    batch: str,
+    scenario: str,
+    *,
+    bat_col: str = "BAT_percustomer_delivery",
+    group_col: str = "postprocess_group.has_hp",
+    group_value: bool = True,
+) -> dict:
+    """Weighted mean and total $/yr BAT for one group, always read from ``{scenario}_precalc``.
+
+    Positive BAT = overpaying relative to cost of service; negative = underpaying.
+    """
+    import polars as pl
+
+    bat = cast("pl.DataFrame", load_master_bat(state, batch, segment_name(scenario, "precalc")).collect())
+    sub = bat.filter(pl.col(group_col) == group_value)
+    total_per_year = float((sub[bat_col] * sub["weight"]).sum())
+    return {
+        "scenario": scenario,
+        "mean_per_year": weighted_mean(sub, bat_col, "weight"),
+        "total_per_year_millions": total_per_year / 1e6,
+        "n_weighted": float(sub["weight"].sum()),
+    }
+
+
+def bat_by_group(
+    state: str,
+    batch: str,
+    scenario: str,
+    *,
+    bat_col: str = "BAT_percustomer_delivery",
+    group_col: str = "postprocess_group.heating_type_v2",
+) -> pl.DataFrame:
+    """Weighted mean BAT and weighted customer count by *group_col*, read from ``{scenario}_precalc``."""
+    import polars as pl
+
+    bat = cast("pl.DataFrame", load_master_bat(state, batch, segment_name(scenario, "precalc")).collect())
+    return (
+        bat.group_by(group_col)
+        .agg(
+            ((pl.col(bat_col) * pl.col("weight")).sum() / pl.col("weight").sum()).alias("mean_per_year"),
+            pl.col("weight").sum().alias("n_weighted"),
+        )
+        .sort("n_weighted", descending=True)
+    )
+
+
+def compare_bat_across_scenarios(state: str, batch: str, scenarios: list[str], **kwargs) -> pl.DataFrame:
+    """One row per scenario of ``hp_bat_summary``, for a before/after table.
+
+    E.g. ``compare_bat_across_scenarios(state, batch, ["default", "hp_seasonal_percustomer_passthrough"])``
+    gives the HP subclass's overpayment before and after a reform tariff in one table.
+    """
+    import polars as pl
+
+    rows = [hp_bat_summary(state, batch, scenario, **kwargs) for scenario in scenarios]
+    return pl.DataFrame(rows)
+
+
+# --- Representative household + monthly decomposition ---------------------------
+
+
+def weighted_median_bldg_id(df: pl.DataFrame, sort_col: str, weight_col: str = "weight") -> int:
+    """Return the ``bldg_id`` at the weighted median of *sort_col*.
+
+    Same logic as picking a representative row, but returns just the ID so it
+    can be reused to select a representative building from any filtered
+    population, then pull whatever other data (e.g. monthly bills) is needed
+    for that specific building.
+    """
+    total_weight = float(df[weight_col].sum())
+    sorted_df = df.sort(sort_col)
+    cum = sorted_df[weight_col].cum_sum()
+    median_row = sorted_df.filter(cum >= 0.5 * total_weight).head(1)
+    if median_row.is_empty():
+        raise ValueError("Cannot compute weighted median bldg_id: empty data or non-positive weights")
+    return int(median_row["bldg_id"][0])
+
+
+def monthly_bill_components(state: str, batch: str, segment: str, bldg_id: int) -> pl.DataFrame:
+    """Return one building's 12 monthly electric bill rows, decomposed into delivery vs. supply.
+
+    Long-form ``(month, component, value)``, ``component`` in
+    ``{"Electric Delivery Bill", "Electric Supply Bill"}``
+    (``elec_fixed_charge + elec_delivery_bill`` vs. ``elec_supply_bill``).
+    ``month`` is ordered Jan-Dec (the ``"Annual"`` row is excluded).
+    """
+    import polars as pl
+
+    filtered = (
+        load_master_bills(state, batch, segment)
+        .filter((pl.col("bldg_id") == bldg_id) & (pl.col("month") != "Annual"))
+        .select(
+            pl.col("month").cast(pl.Enum(MONTH_ORDER)),
+            (pl.col("elec_fixed_charge") + pl.col("elec_delivery_bill")).alias("Electric Delivery Bill"),
+            pl.col("elec_supply_bill").alias("Electric Supply Bill"),
+        )
+    )
+    bills = cast("pl.DataFrame", filtered.collect()).sort("month")
+    return bills.unpivot(
+        on=["Electric Delivery Bill", "Electric Supply Bill"],
+        index="month",
+        variable_name="component",
+        value_name="value",
+    )
+
+
+# --- Tariff introspection --------------------------------------------------------
+
+
+def load_tariff_json(state: str, utility: str, stem: str, ref: str) -> dict:
+    """Fetch and parse a URDB tariff JSON from rate-design-platform's electric tariff config.
+
+    *ref* has no default: every call site must pass the notebook's pinned
+    ``RDP_REF`` (read from ``batch_config.yaml``) explicitly, so the tariff JSON
+    always comes from the exact commit paired with the CAIRO batch, never a
+    possibly-drifted ``main``.
+    """
+    from lib.rdp import fetch_rdp_file, parse_urdb_json
+
+    del utility  # reserved for future multi-utility batches; path is state-scoped today
+    path = f"rate_design/hp_rates/{state.lower()}/config/tariffs/electric/{stem}.json"
+    content = fetch_rdp_file(path, ref=ref)
+    return parse_urdb_json(content)["items"][0]
+
+
+def extract_tariff_rates(tariff: dict) -> dict:
+    """Extract fixed charge, per-period volumetric rates, and the month->period map from a URDB tariff.
+
+    Works for flat (1-period), quarterly-ish (N-period, no seasonal grouping),
+    and seasonal (N-period, grouped by month) tariffs alike — the caller decides
+    how to use ``month_to_period`` based on how many distinct periods there are.
+
+    Returns a dict with:
+
+    - ``fixed_charge``: monthly fixed charge ($/month)
+    - ``period_rates``: ``{period_index: rate}`` ($/kWh)
+    - ``month_to_period``: ``{month_abbrev: period_index}`` (e.g. ``{"Jan": 1, ...}``),
+      built from ``energyweekdayschedule`` (one row per month, Jan first)
+    """
+    fixed_charge = float(tariff.get("fixedchargefirstmeter", 0.0))
+    period_rates = {i: float(tiers[0]["rate"]) for i, tiers in enumerate(tariff["energyratestructure"])}
+    weekday_schedule = tariff.get("energyweekdayschedule", [])
+    month_to_period = {MONTH_ORDER[i]: int(row[0]) for i, row in enumerate(weekday_schedule)}
+    return {
+        "fixed_charge": fixed_charge,
+        "period_rates": period_rates,
+        "month_to_period": month_to_period,
+    }

--- a/reports/md_hp_rates/batch_config.yaml
+++ b/reports/md_hp_rates/batch_config.yaml
@@ -1,0 +1,5 @@
+BATCH: md_20260803_a
+RDP_REF: 562bb33
+S3_BASE: "s3://data.sb/switchbox/cairo/outputs/hp_rates"
+STATE: "MD"
+BASELINE_BILL_SCENARIO: "default"

--- a/reports/md_hp_rates/index.qmd
+++ b/reports/md_hp_rates/index.qmd
@@ -30,27 +30,64 @@ citation:
 #    href: docs/switchbox_report.pdf
 ---
 
+```{python}
+#| echo: false
+
+import pickle
+from pathlib import Path
+from types import SimpleNamespace
+
+v = SimpleNamespace(**pickle.loads(Path("cache/report_variables.pkl").read_bytes()))
+
+
+def dollar(x, accuracy=0):
+    return f"${x:,.{accuracy}f}"
+
+
+def million(x, digits=1):
+    return f"${x:,.{digits}f} million"
+
+
+def pct(x, accuracy=0):
+    return f"{x * 100:,.{accuracy}f}%"
+
+
+def cents(x, accuracy=2):
+    return f"{x:,.{accuracy}f}"
+```
+
 # Introduction
 
 # Executive Summary
 
-- If you are a BGE customer (on schedule R) and you go from natural gas to a heat pump, your total annual energy bills go up TK% of the time
-- HP customers (on schedule R) are being overcharged by an average of $TK a year
+- If you are a BGE customer (on schedule R) and you go from natural gas to a heat pump, your total annual energy bills go up `{python} pct(v.pct_natgas_hp_bill_increase_default)` of the time
+- HP customers (on schedule R) are being overcharged by an average of `{python} dollar(v.hp_overpay_mean_default)` a year
     - Since this is on the delivery side, it's the same on RL, because it has essentially the same volumetric delivery rate
-- A TOU rate doesn't fix it: HP customers on schedule RD would still be overcharged by an average of $TK a year
+- A TOU rate doesn't fix it: HP customers on schedule RD would still be overcharged by an average of $TK a year[^tou-blocked]
+
+[^tou-blocked]: No time-of-use (Schedule RD) scenario has been run for this batch yet — BGE's pipeline config only defines `default` and `hp_seasonal_percustomer_passthrough` scenarios so far. Once a TOU scenario exists, the same delivery Bill Alignment Test used elsewhere in this report answers this directly.
+
 - There are two ways to fix this
     - Lower the volumetric rate by raising the fixed charge (and maybe by making the volumetric rate seasonal... but in a revenue-neutral way.)
-        - You'd have to raise it to $TK a month from $TK today in order to eliminate the cross-subsidy.
+        - You'd have to raise it to $TK a month from `{python} dollar(v.tariff_default_fixed_charge)` today in order to eliminate the cross-subsidy.[^fixed-charge-blocked]
             - Is this equivalent to making the fixed charge equal residual costs, and having volumetric just cover marginal?
         - If you do this on the default rate, it is very disruptive.
-        - If you do this via an optional rate that anyone can access, then it would raise the bills of TK% of existing HP customers compared to being on schedule R
-        - Bill impact if you do this: TK percentage points more people can save by moving to heat pumps
-        - Energy burden impact if you do this: under current HVAC TK% of customers are burdened. This changes to TK% under heat pumps and default rates. And it changes to TK% under heat pumps and higher fixed charge.
+        - If you do this via an optional rate that anyone can access, then it would raise the bills of `{python} pct(1 - v.pct_hp_bill_decrease_seasonal_ratedesign)` of existing HP customers compared to being on schedule R[^optional-rate-modeled]
+        - Bill impact if you do this: `{python} f"{v.pct_pt_improvement_natgas_hp_savings:.0f}"` percentage points more people can save by moving to heat pumps[^optional-rate-modeled]
+        - Energy burden impact if you do this: under current HVAC TK% of customers are burdened. This changes to TK% under heat pumps and default rates. And it changes to TK% under heat pumps and higher fixed charge.[^burden-blocked]
     - Lower the volumetric rate full stop, which only works through a tech-specific rate
-        - Under a flat design, the volumetric delivery would have to go from $TK per kWh today to $TK to eliminate the overpayment
-            - The bill impact on other customers would be $TK per month
-        - If you wanted to do this through a seasonal design, the volumetric delivery rate would stay the same in summer but would drop to $TK per kWh in winter.
-        - Energy burden impact if you do this: under current HVAC TK% of customers are burdened. This changes to TK% under heat pumps and default rates. And it changes to TK% under heat pumps and lower volumetric rate.
+        - Under a flat design, the volumetric delivery would have to go from $TK per kWh today to $TK to eliminate the overpayment[^flat-blocked]
+            - The bill impact on other customers would be $TK per month[^flat-blocked]
+        - If you wanted to do this through a seasonal design, the volumetric delivery rate would stay roughly the same in summer (`{python} cents(v.tariff_seasonal_summer_cents)`&cent;/kWh, vs. `{python} cents(v.tariff_default_avg_cents)`&cent;/kWh today) but would drop to `{python} cents(v.tariff_seasonal_winter_cents)`&cent;/kWh in winter (@fig-monthly-bill-representative).
+        - Energy burden impact if you do this: under current HVAC TK% of customers are burdened. This changes to TK% under heat pumps and default rates. And it changes to TK% under heat pumps and lower volumetric rate.[^burden-blocked]
+
+[^fixed-charge-blocked]: No CAIRO scenario has actually raised BGE's fixed charge yet — the one reform tariff calibrated so far (`hp_seasonal_percustomer_passthrough`) keeps the `{python} dollar(v.tariff_default_fixed_charge)`/month fixed charge unchanged and instead moves the residual revenue requirement into a seasonal volumetric rate. See the analysis notebook's "What the tariff actually changed" section.
+
+[^optional-rate-modeled]: BGE's pipeline hasn't calibrated a fixed-charge-based optional rate. The only optional rate that's actually been modeled is the seasonal tech-specific rate described below, which is assigned automatically by subclass rather than by customer choice: every building in the heat-pump subclass sees a bill *decrease* under it (not an increase), since it's calibrated to reflect their delivery cost of service, and gas-to-heat-pump conversions save money `{python} f"{v.pct_pt_improvement_natgas_hp_savings:.0f}"` more percentage points of the time than under schedule R.
+
+[^burden-blocked]: Energy burden analysis is deferred this pass. `in.representative_income` is already present in the master bills table for a follow-up.
+
+[^flat-blocked]: No flat-rate heat-pump scenario has been run for this batch — only the seasonal tech-specific design above exists. `rate_case_funcs.py`'s functions (`extract_tariff_rates`, `bill_delta_between_segments`, `hp_bat_summary`) are written generically over scenario, so answering this is a config-only follow-up once a flat scenario is run, not new code.
 
 - Headroom analysis?
 - Cost-of-service calculation using NCP allocators doesn't make sense
@@ -65,13 +102,35 @@ citation:
     - However, the new T&D costs associated with that new load are only X%, not TK%: by using cooling in the top 100 loads hours of the year, they impose approximately $TK in new distribution costs and $TK in transmission costs, in any given year. But they are being charged $TK and $TK extra.
     - That extra revenue has the effect of pushing rates down, which means that fossil-heating customers end up paying LESS than they would otherwise (than their cost to serve).
     - This also happens with riders, by the way: given that the budgets they collect are fixed in any given year, if my contribution to said program doubles from one year to the next, other people are get to pay less than they would have otherwise. Cross-subsidy still happens!
-    - In total, HP customers are overpaying by $TK million a year across BGE's territory.
-        - (Overpayment here is defined as incremental delivery bill - incremental marginal cost, so we'd need to estimate this for people currently on heat pumps.)
+    - In total, HP customers are overpaying by `{python} million(v.hp_overpay_total_millions_default)` a year across BGE's territory.
+        - (Overpayment here is defined as incremental delivery bill - incremental marginal cost, so we'd need to estimate this for people currently on heat pumps — this is exactly the delivery Bill Alignment Test total from earlier in this summary.)
     - We are charging HP customers more than their incremental cost of service in order to subsidize the electrical bills of the customers who heat in the ways that the state of MD is trying to move away from.
 
 # Background
 
 # Findings
+
+## What happens to a representative household under the seasonal rate?
+
+To make the seasonal tech-specific rate concrete, we follow a single representative BGE
+home: the weighted-median natural-gas-heated household, ranked by its annual energy bill
+today. This household currently pays `{python} dollar(v.representative_annual_bill_before)`
+a year for natural gas heat and electricity. After switching to a heat pump under the
+seasonal reform rate, its annual energy bill becomes
+`{python} dollar(v.representative_annual_bill_after)`. Its monthly electric bill, split into
+delivery and supply, shows the seasonal design at work (@fig-monthly-bill-representative):
+
+:::{.column-page-inset-right}
+{{< embed notebooks/analysis.qmd#fig-monthly-bill-representative >}}
+:::
+
+The delivery share of this household's bill is lowest in the winter months — January,
+February, March, November, and December — precisely when its heat-pump heating load, and
+its total electricity consumption, is highest. That's the seasonal rate design doing its
+job: the winter volumetric delivery rate is lower specifically because that's when heat
+pump customers use the most electricity, so the same lower rate that reduces their annual
+overpayment also shows up concretely in their monthly bills, in the months that matter most
+to them.
 
 # Appendix
 

--- a/reports/md_hp_rates/notebooks/analysis.qmd
+++ b/reports/md_hp_rates/notebooks/analysis.qmd
@@ -1,9 +1,12 @@
 ---
-title: ANALYSIS TEMPLATE
+title: BGE Rate Case Analysis
 
 toc: true
 reference-location: margin
 fig-cap-location: bottom
+execute:
+  warning: false
+  message: false
 
 appendix-style: default
 citation-location: document
@@ -14,3 +17,588 @@ format:
   html:
     page-layout: full
 ---
+
+This notebook contains the analysis behind the BGE (Baltimore Gas and Electric) rate case
+report. Starting from CAIRO simulation outputs on S3, it computes every statistic that
+appears in the report narrative (`index.qmd`).
+
+The functions doing the actual data crunching live in
+[`lib/rates_analysis/rate_case_funcs.py`](../../../lib/rates_analysis/rate_case_funcs.py), a
+module generalized over state, batch, and scenario so it can be reused for other utilities
+and future tariff designs (e.g. a flat-rate heat pump tariff) without changes. This notebook
+just calls those functions with BGE's specific state/batch/scenario values.
+
+The analysis follows the report's arc:
+
+1. **Bill-increase incidence today** — how often switching from natural gas to a heat pump
+   raises a customer's total energy bill under BGE's current (Schedule R) rates.
+2. **Cross-subsidization** — the Bill Alignment Test (BAT), showing heat pump customers
+   systematically overpay for electric delivery under today's rates.
+3. **A tech-specific seasonal rate** — the one reform tariff CAIRO has calibrated so far,
+   and what it does to the cross-subsidy, to bill incidence, and to a representative
+   household's monthly bills.
+4. **What's blocked** — a time-of-use rate and a flat-rate tech-specific design are both
+   discussed in the report, but neither has a CAIRO scenario yet; this notebook flags those
+   gaps explicitly rather than fabricating numbers for them.
+
+## Setup
+
+```{python}
+#| label: setup
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import yaml
+import plotnine as plt
+from great_tables import GT
+
+
+from lib.plotnine import SB_COLORS, theme_switchbox
+from lib.great_tables import get_switchbox_gt_tab_options
+from lib.quarto import display_gt
+from lib.rates_analysis.rate_case_funcs import (
+    MONTH_ORDER,
+    bat_by_group,
+    bill_change_incidence,
+    bill_delta_between_segments,
+    compare_bat_across_scenarios,
+    extract_tariff_rates,
+    hp_bat_summary,
+    load_master_bills,
+    load_tariff_json,
+    monthly_bill_components,
+    segment_name,
+    weighted_median_bldg_id,
+)
+
+
+report_vars: dict = {}
+```
+
+## Parameters
+
+Batch and tariff-fetch pin (`RDP_REF`) live in `batch_config.yaml` alongside this report, not
+hardcoded here, so re-running against a new batch is a one-file change. `RDP_REF` is a fixed
+git commit SHA (not `main`) — the exact `rate-design-platform` commit that introduced the
+scenario/tariff configs this batch was run against — so tariff JSONs are always fetched from
+the code that actually produced this batch's numbers, even if `main` moves on later.
+
+```{python}
+#| label: params
+
+_batch_config = yaml.safe_load(Path("../batch_config.yaml").read_text())
+
+STATE = _batch_config["STATE"]
+BATCH = _batch_config["BATCH"]
+RDP_REF = _batch_config["RDP_REF"]
+UTILITY = "bge"
+
+DEFAULT_SCENARIO = _batch_config["BASELINE_BILL_SCENARIO"]
+SEASONAL_SCENARIO = "hp_seasonal_percustomer_passthrough"
+
+print(f"state={STATE}  batch={BATCH}  rdp_ref={RDP_REF}  utility={UTILITY}")
+```
+
+Batch `md_20260803_a` has two calibrated scenarios for BGE, each run at two stages:
+
+- `precalc` — ResStock upgrade 00 (today's mixed heating population), tariff as filed/priced.
+- `calibrated` — ResStock upgrade 02 (same buildings retrofitted to heat pumps), tariff
+  recalibrated to meet each subclass's revenue requirement under that scenario's design.
+
+| Scenario | What it is |
+| --- | --- |
+| `default` | BGE's current Schedule R-like tariff (a single rate schedule for all residential customers). |
+| `hp_seasonal_percustomer_passthrough` | A subclass-differentiated pair of tariffs, assigned automatically by each building's modeled heating type (`has_hp`), not by customer choice: the heat-pump subclass gets a seasonal volumetric delivery rate (same fixed charge as `default`); the non-heat-pump subclass gets its own separate, recalibrated tariff (`non-hp_base_percustomer_passthrough`) rather than staying on `default`, since the revenue no longer collected from the heat-pump subclass has to be made up somewhere. The residual (non-marginal-cost) revenue requirement is allocated per customer within each subclass. |
+
+No time-of-use (schedule RD) or flat-rate heat-pump scenario exists yet in BGE's pipeline
+config — the report bullets that depend on those are flagged as blocked below, not filled in
+with invented numbers.
+
+## Import data
+
+The master bills and BAT tables are pre-built, Hive-partitioned parquet datasets — one row
+per building per month (bills) or per building (BAT) — with ResStock metadata columns
+already joined in. We load all four segments as LazyFrames; nothing is materialized until a
+later cell filters and collects what it needs.
+
+```{python}
+#| label: ingest
+
+SEG_DEFAULT_PRECALC = segment_name(DEFAULT_SCENARIO, "precalc")
+SEG_DEFAULT_CALIBRATED = segment_name(DEFAULT_SCENARIO, "calibrated")
+SEG_SEASONAL_PRECALC = segment_name(SEASONAL_SCENARIO, "precalc")
+SEG_SEASONAL_CALIBRATED = segment_name(SEASONAL_SCENARIO, "calibrated")
+
+bills_default_precalc = load_master_bills(STATE, BATCH, SEG_DEFAULT_PRECALC)
+bills_default_calibrated = load_master_bills(STATE, BATCH, SEG_DEFAULT_CALIBRATED)
+bills_seasonal_precalc = load_master_bills(STATE, BATCH, SEG_SEASONAL_PRECALC)
+bills_seasonal_calibrated = load_master_bills(STATE, BATCH, SEG_SEASONAL_CALIBRATED)
+```
+
+Let's look at a sample of the `default_precalc` bills to see what's in the table, and check
+the sample size — how many ResStock buildings we have, and how many actual BGE residential
+customers they represent once we sum ResStock's sample weights.
+
+```{python}
+#| label: sample-size
+
+_sample = (
+    bills_default_precalc
+    .filter(pl.col("month") == "Annual")
+    .select("bldg_id", "weight", "postprocess_group.heating_type_v2", "postprocess_group.has_hp", "energy_total_bill")
+    .collect()
+)
+print(_sample.head())
+
+n_resstock_bldgs = _sample["bldg_id"].n_unique()
+n_bge_customers = float(_sample["weight"].sum())
+report_vars["n_resstock_bldgs"] = n_resstock_bldgs
+report_vars["n_bge_customers"] = n_bge_customers
+print(f"Unique ResStock buildings: {n_resstock_bldgs:,}")
+print(f"Total BGE residential customers (sum of weights): {n_bge_customers:,.0f}")
+```
+
+Every building appears in all four segments (`default`/`hp_seasonal_percustomer_passthrough`
+× `precalc`/`calibrated`) — confirmed by checking that each segment's `bldg_id` set is
+identical, which is what makes the same-tariff before/after comparisons and same-stage
+cross-scenario comparisons below valid (they're diffing the same population against itself).
+
+## Bill-increase incidence switching from natural gas to a heat pump, under today's rate
+
+How often does a natural-gas-heated BGE home end up with a *higher* total annual energy bill
+(electric + gas) after switching to a heat pump, if nothing about the rate design changes?
+We diff each building's annual `energy_total_bill` between `default_precalc` (today's HVAC,
+today's tariff) and `default_calibrated` (same building retrofitted to a heat pump, same
+tariff family, recalibrated for the new load) — a same-scenario, before/after-retrofit
+comparison — restricted to buildings whose baseline heating fuel is natural gas.
+
+```{python}
+#| label: compute-natgas-hp-delta-default
+
+delta_natgas_default = bill_delta_between_segments(
+    STATE, BATCH, SEG_DEFAULT_PRECALC, SEG_DEFAULT_CALIBRATED
+).filter(pl.col("heating_type_v2") == "natgas")
+
+incidence_natgas_default = bill_change_incidence(delta_natgas_default)
+incidence_natgas_default
+```
+
+```{python}
+#| label: report-vars-natgas-hp-delta-default
+
+report_vars["pct_natgas_hp_bill_increase_default"] = incidence_natgas_default["pct_increase"]
+report_vars["pct_natgas_hp_bill_decrease_default"] = incidence_natgas_default["pct_decrease"]
+report_vars["mean_natgas_hp_bill_increase_default"] = incidence_natgas_default["mean_delta"]
+report_vars["median_natgas_hp_bill_increase_default"] = incidence_natgas_default["median_delta"]
+```
+
+**`{python} f"{report_vars['pct_natgas_hp_bill_increase_default']:.0%}"` of natural-gas-heated
+BGE homes would see their total annual energy bill go up** after switching to a heat pump
+under today's rate — a mean increase of `{python} f"${report_vars['mean_natgas_hp_bill_increase_default']:,.0f}"`
+a year (median `{python} f"${report_vars['median_natgas_hp_bill_increase_default']:,.0f}"`).
+The rest see a decrease, mostly from avoided gas costs outweighing the added electric load.
+
+## Heat pump customers are overpaying for delivery today
+
+Even setting bill *changes* aside, existing heat pump customers already pay more for
+electric delivery than their incremental cost of service justifies — the Bill Alignment Test
+(BAT) quantifies this directly. BAT values are only meaningful at the `precalc` stage (see
+the module docstring in `rate_case_funcs.py`): the `calibrated` stage's revenue requirement is
+deliberately inflated for calibration purposes, so its BAT is not a valid cross-subsidy
+measure even though the bills themselves are correct there.
+
+```{python}
+#| label: hp-bat-summary-default
+
+bat_default_hp = hp_bat_summary(STATE, BATCH, DEFAULT_SCENARIO)
+bat_default_hp
+```
+
+```{python}
+#| label: report-vars-hp-bat-default
+
+report_vars["hp_overpay_mean_default"] = bat_default_hp["mean_per_year"]
+report_vars["hp_overpay_total_millions_default"] = bat_default_hp["total_per_year_millions"]
+report_vars["hp_share_of_households_default"] = bat_default_hp["n_weighted"] / n_bge_customers
+```
+
+**Heat pump customers on Schedule R overpay for delivery by an average of
+`{python} f"${report_vars['hp_overpay_mean_default']:,.0f}"` a year** — `{python} f"${report_vars['hp_overpay_total_millions_default']:.1f}"`
+million a year in total across BGE's roughly `{python} f"{report_vars['hp_share_of_households_default']:.0%}"`
+heat-pump-heated residential population. That overpayment isn't unique to heat pumps — it's
+a feature of BGE's uniform volumetric delivery rate. The same table, split by baseline
+heating type, shows every all-electric subclass overpaying and every fossil-fuel subclass
+underpaying relative to their delivery cost of service:
+
+```{python}
+#| label: tbl-bat-by-heating-type
+#| tbl-cap: "Average delivery over/underpayment by baseline heating type, relative to cost of service (BGE, Schedule R)."
+
+_bat_by_type = bat_by_group(STATE, BATCH, DEFAULT_SCENARIO)
+_bat_by_type_gt = (
+    GT(_bat_by_type, rowname_col="postprocess_group.heating_type_v2")
+    .fmt_currency(columns="mean_per_year", decimals=0)
+    .fmt_number(columns="n_weighted", decimals=0)
+    .cols_label(mean_per_year="Average over/underpayment", n_weighted="Weighted customers")
+    .tab_stubhead(label="Baseline heating type")
+    .tab_source_note("Positive = overpaying delivery cost of service; negative = underpaying.")
+    .tab_options(**get_switchbox_gt_tab_options())
+)
+display_gt(_bat_by_type_gt)
+```
+
+Delivery rates are volumetric, so this result doesn't depend on which specific rate schedule
+a customer is on — Schedule RL has essentially the same volumetric delivery rate as Schedule R,
+so the same overpayment applies there too (this isn't separately re-derived here since it
+follows directly from the rate structure, not from a separate CAIRO run).
+
+## A time-of-use rate doesn't fix it — but we can't show that yet
+
+::: {.callout-note}
+No time-of-use (Schedule RD) scenario has been run for this batch — `pipeline_bge.yaml` only
+defines `default` and `hp_seasonal_percustomer_passthrough` scenarios so far. The report's
+TOU claim is left as `TK` rather than filled in with a fabricated number. Once a TOU scenario
+exists, the exact same `hp_bat_summary()` call used above answers this — no new code needed.
+:::
+
+## Fixing the cross-subsidy with a tech-specific seasonal rate
+
+The report describes two ways to eliminate the heat-pump delivery cross-subsidy: raise the
+fixed charge (lowering the volumetric rate for everyone, revenue-neutral), or lower the
+volumetric rate specifically for heat pump customers via a tech-specific rate. The one reform
+tariff CAIRO has calibrated so far — `hp_seasonal_percustomer_passthrough` — takes the second
+path: a seasonal volumetric delivery rate for the heat-pump subclass, paired with a separate
+recalibrated tariff for the non-heat-pump subclass, with the residual revenue requirement
+allocated per customer within each subclass.
+
+### What the tariff actually changed
+
+We read both tariffs' calibrated URDB JSON directly to see what changed.
+
+```{python}
+#| label: load-tariffs
+
+tariff_default = load_tariff_json(STATE, UTILITY, f"{UTILITY}_default_calibrated", RDP_REF)
+tariff_seasonal = load_tariff_json(STATE, UTILITY, f"{UTILITY}_{SEASONAL_SCENARIO}_calibrated", RDP_REF)
+
+rates_default = extract_tariff_rates(tariff_default)
+rates_seasonal = extract_tariff_rates(tariff_seasonal)
+print("default:", rates_default)
+print("seasonal:", rates_seasonal)
+```
+
+```{python}
+#| label: tbl-tariff-months
+#| tbl-cap: "Volumetric delivery rate by month, today's Schedule R vs. the seasonal heat-pump rate."
+
+def _month_rate_table(rates: dict, label: str) -> pl.DataFrame:
+    return pl.DataFrame({
+        "month": MONTH_ORDER,
+        label: [
+            rates["period_rates"][rates["month_to_period"][m]] * 100
+            for m in MONTH_ORDER
+        ],
+    })
+
+_tariff_months = _month_rate_table(rates_default, "Schedule R (¢/kWh)").join(
+    _month_rate_table(rates_seasonal, "Seasonal HP rate (¢/kWh)"), on="month"
+).with_columns(pl.col("month").cast(pl.Enum(MONTH_ORDER)))
+
+_tariff_months_gt = (
+    GT(_tariff_months, rowname_col="month")
+    .fmt_number(columns=["Schedule R (¢/kWh)", "Seasonal HP rate (¢/kWh)"], decimals=2)
+    .tab_stubhead(label="Month")
+    .tab_options(**get_switchbox_gt_tab_options())
+)
+display_gt(_tariff_months_gt)
+```
+
+```{python}
+#| label: report-vars-tariff-rates
+
+report_vars["tariff_default_fixed_charge"] = rates_default["fixed_charge"]
+report_vars["tariff_seasonal_fixed_charge"] = rates_seasonal["fixed_charge"]
+report_vars["tariff_seasonal_summer_cents"] = rates_seasonal["period_rates"][0] * 100
+report_vars["tariff_seasonal_winter_cents"] = rates_seasonal["period_rates"][1] * 100
+report_vars["tariff_default_avg_cents"] = (
+    sum(rates_default["period_rates"][rates_default["month_to_period"][m]] for m in MONTH_ORDER)
+    / len(MONTH_ORDER)
+    * 100
+)
+```
+
+::: {.callout-important}
+**The calibrated seasonal tariff keeps exactly the same $`{python} f"{report_vars['tariff_default_fixed_charge']:.0f}"`/month
+fixed charge as Schedule R** — we confirmed this both in the tariff JSON and in the master
+bills' `elec_fixed_charge` column (identical for every building in both scenarios). CAIRO's
+"per-customer" residual allocation here is expressed entirely through the seasonal
+*volumetric* rate, not a higher fixed charge. That means **this scenario does not answer the
+report's "raise the fixed charge" question** (the bullets asking what fixed charge would be
+needed, and what a fixed-charge-based optional rate would do to existing HP customers and
+bill incidence) — no CAIRO scenario has actually raised BGE's fixed charge yet, for anyone.
+Those bullets are left as `TK` below rather than answered with a mechanism this data doesn't
+implement.
+
+What this scenario *does* answer is the report's other path: a tech-specific rate that lowers
+the volumetric rate for heat pump customers, done seasonally. The summer rate
+(`{python} f"{report_vars['tariff_seasonal_summer_cents']:.2f}"`¢/kWh, Jun–Sep) is close to
+today's `{python} f"{report_vars['tariff_default_avg_cents']:.2f}"`¢/kWh average, while the
+winter rate drops to `{python} f"{report_vars['tariff_seasonal_winter_cents']:.2f}"`¢/kWh
+(Jan–May, Oct–Dec) — confirming the report's framing that a seasonal tech-specific design
+would hold the summer rate roughly flat while cutting the winter rate.
+:::
+
+### Does the seasonal rate actually eliminate the cross-subsidy?
+
+`hp_bat_summary()` on the `default` scenario already gave us the "before" number above
+(`{python} f"${report_vars['hp_overpay_mean_default']:,.0f}"`/yr). `compare_bat_across_scenarios()`
+adds the "after" number in the same table, so we can see both without a second, redundant
+call:
+
+```{python}
+#| label: tbl-bat-before-after
+#| tbl-cap: "Heat pump customers' average delivery overpayment, before and after the seasonal reform tariff."
+
+_bat_compare = compare_bat_across_scenarios(STATE, BATCH, [DEFAULT_SCENARIO, SEASONAL_SCENARIO])
+_bat_compare_gt = (
+    GT(_bat_compare.select("scenario", "mean_per_year", "total_per_year_millions"), rowname_col="scenario")
+    .fmt_currency(columns="mean_per_year", decimals=0)
+    .fmt_currency(columns="total_per_year_millions", decimals=1)
+    .cols_label(mean_per_year="Average overpayment ($/yr)", total_per_year_millions="Total ($M/yr)")
+    .tab_stubhead(label="Scenario")
+    .tab_options(**get_switchbox_gt_tab_options())
+)
+display_gt(_bat_compare_gt)
+```
+
+```{python}
+#| label: report-vars-bat-seasonal
+
+report_vars["hp_overpay_mean_seasonal"] = float(
+    _bat_compare.filter(pl.col("scenario") == SEASONAL_SCENARIO)["mean_per_year"][0]
+)
+```
+
+Under the seasonal rate, the heat-pump subclass's average delivery overpayment falls to
+essentially zero (`{python} f"${report_vars['hp_overpay_mean_seasonal']:,.2f}"`/yr) — CAIRO
+calibrated the seasonal volumetric rate specifically to close this gap, so this confirms the
+calibration worked rather than solving anything new.
+
+### Isolating the rate-design effect, before anyone retrofits
+
+This comparison holds HVAC equipment fixed and changes only the tariff, so the bill change it
+measures is purely a rate-design effect, not a retrofit effect. To be precise about what's
+being compared:
+
+- **Population**: every BGE residential customer, split into the two subclasses used by the
+  reform tariff — the **heat-pump subclass** (buildings our model assigns a heat pump to,
+  `has_hp == true`) and the **non-heat-pump subclass** (everyone else). This split is
+  automatic, based on each building's modeled heating type — not a choice a customer makes.
+- **HVAC, before and after**: base/pre-retrofit (`upgrade=00`) for both subclasses in both the
+  "before" and "after" case. Nobody has actually installed a heat pump in either segment being
+  compared here — `default_precalc` and `hp_seasonal_percustomer_passthrough_precalc` are both
+  `upgrade=00` runs.
+- **Tariff, before**: today's Schedule R, applied identically to both subclasses.
+- **Tariff, after**: the reform tariff pair — the heat-pump subclass moves to the seasonal
+  rate examined above, and the non-heat-pump subclass moves to its own separate, recalibrated
+  tariff (`non-hp_base_percustomer_passthrough`), not an unchanged Schedule R, since the
+  revenue no longer collected from the heat-pump subclass has to be recovered somewhere.
+
+```{python}
+#| label: compute-ratedesign-delta
+
+delta_ratedesign = bill_delta_between_segments(STATE, BATCH, SEG_DEFAULT_PRECALC, SEG_SEASONAL_PRECALC)
+
+incidence_hp_ratedesign = bill_change_incidence(delta_ratedesign.filter(pl.col("has_hp")))
+incidence_nonhp_ratedesign = bill_change_incidence(delta_ratedesign.filter(~pl.col("has_hp")))
+print("heat-pump subclass, Schedule R -> seasonal rate:", incidence_hp_ratedesign)
+print("non-heat-pump subclass, Schedule R -> recalibrated non-HP tariff:", incidence_nonhp_ratedesign)
+```
+
+```{python}
+#| label: report-vars-ratedesign-delta
+
+report_vars["hp_mean_bill_change_seasonal_ratedesign"] = incidence_hp_ratedesign["mean_delta"]
+report_vars["pct_hp_bill_decrease_seasonal_ratedesign"] = incidence_hp_ratedesign["pct_decrease"]
+report_vars["nonhp_mean_bill_change_seasonal_ratedesign"] = incidence_nonhp_ratedesign["mean_delta"]
+report_vars["pct_nonhp_bill_increase_seasonal_ratedesign"] = incidence_nonhp_ratedesign["pct_increase"]
+```
+
+Every building in the heat-pump subclass sees its bill fall under the reform tariff — a mean
+decrease of `{python} f"${-report_vars['hp_mean_bill_change_seasonal_ratedesign']:,.0f}"` a
+year, even before any of them have installed a heat pump — because the seasonal rate was
+calibrated to charge that subclass its (pre-retrofit) cost of service. That decrease has to
+come from somewhere: the non-heat-pump subclass's recalibrated tariff raises their bills by a
+mean of `{python} f"${report_vars['nonhp_mean_bill_change_seasonal_ratedesign']:,.0f}"` a
+year, because removing the heat-pump subsidy shifts BGE's residual revenue requirement onto
+everyone else. (This is the seasonal tech-specific rate's version of the report's "impact on
+other customers" question — the fixed-charge version of that question is blocked, per the
+callout above.)
+
+The mean hides how that increase is distributed across the non-heat-pump subclass — most see
+a small bump, but the distribution has a tail (@fig-hist-nonhp-ratedesign).
+
+```{python}
+#| label: fig-hist-nonhp-ratedesign
+#| fig-cap: "Distribution of the annual bill change for the non-heat-pump subclass, from Schedule R to the recalibrated non-HP tariff under the seasonal fair scenario (same, pre-retrofit HVAC throughout)."
+
+(
+    plt.ggplot(delta_ratedesign.filter(~pl.col("has_hp")))
+    + plt.aes(x="delta")
+    + plt.geom_histogram(binwidth=25, fill=SB_COLORS["midnight"])
+    + plt.geom_vline(
+        xintercept=incidence_nonhp_ratedesign["median_delta"],
+        color=SB_COLORS["carrot"],
+        linetype="dashed",
+    )
+    + plt.labs(x="Change in annual energy bill ($)", y="Count of households")
+    + plt.scale_x_continuous(
+        breaks=lambda limits: list(range(
+            (int(limits[0]) // 50) * 50,
+            int(limits[1]) + 50,
+            50,
+        )),
+        labels=lambda xs: [
+            f"${x:,.0f}" if x >= 0 else f"-${abs(x):,.0f}" for x in xs
+        ],
+        minor_breaks=[],
+    )
+    + theme_switchbox()
+    + plt.theme(figure_size=(10.5, 4.5))
+)
+```
+
+### Does the seasonal rate change how many heat pump conversions save money?
+
+We repeat the natural-gas → heat-pump retrofit comparison from the first section, but this
+time under the seasonal reform tariff instead of Schedule R.
+
+```{python}
+#| label: compute-natgas-hp-delta-seasonal
+
+delta_natgas_seasonal = bill_delta_between_segments(
+    STATE, BATCH, SEG_SEASONAL_PRECALC, SEG_SEASONAL_CALIBRATED
+).filter(pl.col("heating_type_v2") == "natgas")
+
+incidence_natgas_seasonal = bill_change_incidence(delta_natgas_seasonal)
+incidence_natgas_seasonal
+```
+
+```{python}
+#| label: report-vars-natgas-hp-delta-seasonal
+
+report_vars["pct_natgas_hp_bill_increase_seasonal"] = incidence_natgas_seasonal["pct_increase"]
+report_vars["pct_natgas_hp_bill_decrease_seasonal"] = incidence_natgas_seasonal["pct_decrease"]
+report_vars["pct_pt_improvement_natgas_hp_savings"] = (
+    (incidence_natgas_seasonal["pct_decrease"] - incidence_natgas_default["pct_decrease"]) * 100
+)
+```
+
+Under the seasonal rate, only `{python} f"{report_vars['pct_natgas_hp_bill_increase_seasonal']:.0%}"`
+of natural-gas homes would see a bill increase after switching to a heat pump — down from
+`{python} f"{report_vars['pct_natgas_hp_bill_increase_default']:.0%}"` under Schedule R. That's
+`{python} f"{report_vars['pct_pt_improvement_natgas_hp_savings']:.0f}"` more percentage points
+of natural-gas customers who'd come out ahead switching to a heat pump.
+
+### A representative household's monthly bills, before and after
+
+To make the seasonal design concrete, we pick the weighted-median natural-gas-heated BGE home
+(by annual `energy_total_bill` today) and follow that same building through to a heat pump,
+under the seasonal rate — showing its actual monthly electric bill, split into delivery and
+supply.
+
+```{python}
+#| label: pick-representative-household
+
+_natgas_baseline = (
+    bills_default_precalc
+    .filter(pl.col("month") == "Annual")
+    .filter(pl.col("postprocess_group.heating_type_v2") == "natgas")
+    .select("bldg_id", "weight", "energy_total_bill")
+    .collect()
+)
+median_natgas_bldg_id = weighted_median_bldg_id(_natgas_baseline, "energy_total_bill")
+print(f"Representative natural-gas-heated building: bldg_id={median_natgas_bldg_id}")
+```
+
+```{python}
+#| label: fig-monthly-bill-representative
+#| fig-cap: "A representative BGE home's monthly electric bill after switching to a heat pump, under the seasonal rate."
+
+_monthly = monthly_bill_components(STATE, BATCH, SEG_SEASONAL_CALIBRATED, median_natgas_bldg_id)
+
+_COMPONENT_ORDER = ["Electric Supply Bill", "Electric Delivery Bill"]
+_COMPONENT_COLORS = {
+    "Electric Delivery Bill": SB_COLORS["midnight"],
+    "Electric Supply Bill": SB_COLORS["carrot"],
+}
+_monthly_plot_df = _monthly.with_columns(pl.col("component").cast(pl.Enum(_COMPONENT_ORDER)))
+
+(
+    plt.ggplot(_monthly_plot_df, plt.aes(x="month", y="value", fill="component"))
+    + plt.geom_col(position="stack", width=0.7)
+    + plt.scale_fill_manual(values=_COMPONENT_COLORS, breaks=_COMPONENT_ORDER)
+    + plt.scale_x_discrete(limits=MONTH_ORDER)
+    + plt.scale_y_continuous(expand=(0, 0, 0.08, 0))
+    + plt.labs(x="", y="$ / month", fill="", title="Monthly electric bill after switching to a heat pump (seasonal rate)")
+    + theme_switchbox()
+    + plt.theme(figure_size=(10.5, 4.5))
+)
+```
+
+```{python}
+#| label: report-vars-representative-household
+
+_before_bill = float(
+    _natgas_baseline.filter(pl.col("bldg_id") == median_natgas_bldg_id)["energy_total_bill"][0]
+)
+_after_bill = float(
+    bills_seasonal_calibrated
+    .filter((pl.col("bldg_id") == median_natgas_bldg_id) & (pl.col("month") == "Annual"))
+    .select("energy_total_bill")
+    .collect()["energy_total_bill"][0]
+)
+report_vars["representative_bldg_id"] = median_natgas_bldg_id
+report_vars["representative_annual_bill_before"] = _before_bill
+report_vars["representative_annual_bill_after"] = _after_bill
+```
+
+For this household, the annual energy bill goes from `{python} f"${report_vars['representative_annual_bill_before']:,.0f}"`
+(natural gas + electric today) to `{python} f"${report_vars['representative_annual_bill_after']:,.0f}"`
+(all-electric heat pump, seasonal rate) — and within that heat-pump bill, the delivery share
+of each monthly bill is lowest in the winter months (Jan, Feb, Mar, Nov, Dec) precisely when
+heating load — and total consumption — is highest, which is what the lower winter volumetric
+rate is designed to do.
+
+## A flat-rate tech-specific design isn't modeled yet
+
+::: {.callout-note}
+No `hp_flat_*` scenario has been run for this batch — only the seasonal design above exists.
+The report's flat-rate bullets (what the flat delivery rate would need to be, and its bill
+impact on other customers) are left as `TK`. Once a flat-rate scenario exists (e.g. a
+`structure: flat` variant of the HP subclass tariff in `pipeline_bge.yaml`), the exact same
+functions used above — `extract_tariff_rates()`, `bill_delta_between_segments()`,
+`hp_bat_summary()` — apply unchanged with `scenario="hp_flat_percustomer_passthrough"` (or
+whatever it's named); none of `rate_case_funcs.py` is scenario-shape-specific.
+:::
+
+## Energy burden — out of scope this pass
+
+The report's energy-burden bullets (bullets asking what share of customers are burdened under
+current HVAC vs. heat pumps, under default vs. reform rates) are deferred; `in.representative_income`
+is already present on the master bills table if this gets picked up in a follow-up.
+
+## Export report variables
+
+```{python}
+#| label: export-report-vars
+
+import pickle
+
+Path("../cache").mkdir(exist_ok=True)
+Path("../cache/report_variables.pkl").write_bytes(pickle.dumps(report_vars))
+report_vars
+```


### PR DESCRIPTION
## Overview

First pass at the BGE (Maryland) rate case. Adds `lib/rates_analysis/rate_case_funcs.py` — the reusable core of the RI heat-pump analysis, generalized over state, batch, scenario, and stage — and uses it to build `reports/md_hp_rates/notebooks/analysis.qmd` and fill the executive summary in `index.qmd`.

Answered from batch `md_20260803_a`: gas-to-heat-pump bill-increase incidence, the delivery cross-subsidy (BAT), what the calibrated seasonal tariff changed, and a representative household's monthly bills. Bullets with no CAIRO scenario yet (TOU, flat-rate tech-specific, energy burden) are left as `TK` with footnotes explaining what's missing, rather than filled with invented numbers.

## Reviewer focus

- **Scenario semantics.** The `precalc` vs `precalc` comparison holds HVAC fixed at pre-retrofit and changes only the tariff, so it isolates rate design from retrofit effects. The notebook spells out population, HVAC, and tariff for before/after — please sanity-check that framing.
- **Non-HP customers do not stay on Schedule R.** Under `hp_seasonal_percustomer_passthrough`, the non-HP subclass gets its own recalibrated tariff (`bge_non-hp_base_percustomer_passthrough`, ~8-9% higher volumetric, same $10 fixed charge). Earlier drafts described this as "unchanged Schedule R," which was wrong.
- **Whether the seasonal scenario answers the fixed-charge bullets.** It does not: the calibrated tariff keeps the fixed charge unchanged and moves the residual into a seasonal volumetric rate. Those bullets stay `TK`.

## Non-obvious implementation details

- `RDP_REF` in `batch_config.yaml` is a fixed commit SHA, not `main`, so tariff JSONs are fetched from the code that produced this batch even after `main` moves on.
- BAT values are only read from `_precalc` segments; `load_master_bat` warns otherwise.
- Functions are scenario-shape-agnostic, so a future flat-rate HP tariff should be a config-only follow-up.

Closes #196

Made with [Cursor](https://cursor.com)